### PR TITLE
feat: add reusable admin guard for admin routes

### DIFF
--- a/src/lib/guards/adminOnly.ts
+++ b/src/lib/guards/adminOnly.ts
@@ -1,0 +1,21 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { error } from '@sveltejs/kit';
+
+export async function ensureAdmin(supabase: SupabaseClient): Promise<void> {
+  const { data: userData, error: userErr } = await supabase.auth.getUser();
+  const email = userData.user?.email ?? null;
+  if (userErr || !email) {
+    throw error(403, 'Només admins');
+  }
+
+  const { data, error: adminErr } = await supabase
+    .from('admins')
+    .select('email')
+    .eq('email', email)
+    .limit(1)
+    .maybeSingle();
+
+  if (adminErr || !data) {
+    throw error(403, 'Només admins');
+  }
+}

--- a/src/routes/admin/+layout.ts
+++ b/src/routes/admin/+layout.ts
@@ -1,0 +1,11 @@
+import type { LayoutLoad } from './$types';
+import { supabase } from '$lib/supabaseClient';
+import { ensureAdmin } from '$lib/guards/adminOnly';
+
+export const ssr = false;
+export const prerender = false;
+
+export const load: LayoutLoad = async () => {
+  await ensureAdmin(supabase);
+  return {};
+};


### PR DESCRIPTION
## Summary
- add `ensureAdmin` helper to verify user is listed in `admins` table and throw 403
- guard admin section via layout load using `ensureAdmin`

## Testing
- `pnpm check`

------
https://chatgpt.com/codex/tasks/task_e_68bf4425356c832eae97ffec2e95b2dc