### PR TITLE
feat: handle invalid dates in ranking

### DIFF
--- a/src/routes/classificacio/+page.svelte
+++ b/src/routes/classificacio/+page.svelte
@@ -8,7 +8,13 @@
     nom: string;
     mitjana: number | null;
     estat: string;
-    assignat_el: string;
+    assignat_el: string | null;
+  };
+
+  const fmtSafe = (iso: string | null): string => {
+    if (!iso) return '—';
+    const d = new Date(iso);
+    return isNaN(d.getTime()) ? '—' : d.toLocaleDateString();
   };
 
   let loading = true;
@@ -61,7 +67,7 @@
             <td class="px-3 py-2">{r.nom}</td>
             <td class="px-3 py-2">{r.mitjana ?? '-'}</td>
             <td class="px-3 py-2 capitalize">{r.estat.replace('_', ' ')}</td>
-            <td class="px-3 py-2">{new Date(r.assignat_el).toLocaleDateString()}</td>
+            <td class="px-3 py-2">{fmtSafe(r.assignat_el)}</td>
           </tr>
         {/each}
       </tbody>


### PR DESCRIPTION
## Summary
- add `fmtSafe` helper to safely format nullable dates
- use `fmtSafe` for the ranking `assignat_el` column to avoid "Invalid Date"

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68bf46cc9e98832e9c469a54f3d22178