### PR TITLE
feat: add challenge RPC helper

### DIFF
--- a/src/lib/domain/challenges.ts
+++ b/src/lib/domain/challenges.ts
@@ -1,0 +1,17 @@
+export type CanCreateResult = { ok: boolean; reason: string | null };
+
+export async function canCreateChallenge(
+  supabase: any,
+  eventId: string,
+  reptadorId: string,
+  reptatId: string
+): Promise<CanCreateResult> {
+  const { data, error } = await supabase.rpc('can_create_challenge', {
+    p_event: eventId,
+    p_reptador: reptadorId,
+    p_reptat: reptatId
+  });
+  if (error) return { ok: false, reason: error.message };
+  if (!data || data.length === 0) return { ok: false, reason: 'No result' };
+  return data[0] as CanCreateResult;
+}


### PR DESCRIPTION
## Summary
- add canCreateChallenge helper for RPC `can_create_challenge`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bfc640b730832eb95eedefeb3305fb