### PR TITLE
Handle walkover results without null tiebreak

### DIFF
--- a/src/routes/admin/reptes/[id]/resultat/+page.svelte
+++ b/src/routes/admin/reptes/[id]/resultat/+page.svelte
@@ -182,11 +182,10 @@
     if (valMsg) { error = valMsg; return; }
     if (!parsedIso) { error = 'Data invàlida.'; return; }
 
-    const resultat = resultEnum();
     const isWalkover = tipusResultat !== 'normal';
+    const resultat = isWalkover ? tipusResultat : resultEnum();
     const _carR = Number(carR), _carT = Number(carT), _entr = Number(entrades);
-    const _tbR  = tiebreak ? Number(tbR) : null;
-    const _tbT  = tiebreak ? Number(tbT) : null;
+    const _tbR = Number(tbR), _tbT = Number(tbT);
 
     try {
       saving = true;
@@ -195,22 +194,21 @@
       const insertRow: any = {
         challenge_id: id,
         data_joc: parsedIso,
-        resultat
+        resultat,
+        tiebreak: isWalkover ? false : !!tiebreak
       };
-      if (!isWalkover) {
+      if (isWalkover) {
+        insertRow.caramboles_reptador = 0;
+        insertRow.caramboles_reptat = 0;
+        insertRow.entrades = 0;
+        insertRow.tiebreak_reptador = 0;
+        insertRow.tiebreak_reptat = 0;
+      } else {
         insertRow.caramboles_reptador = _carR;
         insertRow.caramboles_reptat = _carT;
         insertRow.entrades = _entr;
-        insertRow.tiebreak = tiebreak;
-        insertRow.tiebreak_reptador = _tbR;
-        insertRow.tiebreak_reptat = _tbT;
-      } else {
-        insertRow.caramboles_reptador = null;
-        insertRow.caramboles_reptat = null;
-        insertRow.entrades = null;
-        insertRow.tiebreak = null;
-        insertRow.tiebreak_reptador = null;
-        insertRow.tiebreak_reptat = null;
+        insertRow.tiebreak_reptador = tiebreak ? _tbR : 0;
+        insertRow.tiebreak_reptat = tiebreak ? _tbT : 0;
       }
 
       const { error: e1 } = await supabase.from('matches').insert(insertRow);


### PR DESCRIPTION
## Summary
- avoid null tiebreak and stats on walkover results
- keep tiebreak boolean in normal matches

## Testing
- `pnpm check`


------
https://chatgpt.com/codex/tasks/task_e_68bfdde3685c832e9668b582c72a7892