### PR TITLE
Handle walkover results and tiebreak nulls

### DIFF
--- a/src/routes/admin/reptes/[id]/resultat/+page.svelte
+++ b/src/routes/admin/reptes/[id]/resultat/+page.svelte
@@ -85,9 +85,7 @@
         .maybeSingle();
       if (cfg) settings = cfg;
 
-      data_joc_local =
-        toLocalInput(c.data_acceptacio) ||
-        toLocalInput(new Date().toISOString());
+      data_joc_local = toLocalInput(c.data_acceptacio || new Date().toISOString());
     } catch (e:any) {
       error = e?.message ?? 'Error carregant el repte';
     } finally {
@@ -183,6 +181,7 @@
     if (!parsedIso) { error = 'Data invàlida.'; return; }
 
     const isWalkover = tipusResultat !== 'normal';
+    const hasTB = !isWalkover && !!tiebreak;
 
     try {
       saving = true;
@@ -195,10 +194,10 @@
         caramboles_reptat:   isWalkover ? 0 : Number(carT),
         entrades:            isWalkover ? 0 : Number(entrades),
         resultat: isWalkover ? tipusResultat : resultEnum(),
-        tiebreak: isWalkover ? false : !!tiebreak
+        tiebreak: hasTB
       };
 
-      if (!isWalkover && tiebreak) {
+      if (hasTB) {
         insertRow.tiebreak_reptador = Number(tbR);
         insertRow.tiebreak_reptat   = Number(tbT);
       } else {


### PR DESCRIPTION
## Summary
- Ensure walkover matches send zero scores and null tiebreak fields
- Force default game date to a valid ISO string for the datetime input
- Use hasTB flag so tiebreak data only sent when needed

## Testing
- `pnpm check`

------
https://chatgpt.com/codex/tasks/task_e_68bffb9470c0832e82eec110a31f54de