### PR TITLE
feat: manage personal challenges

### DIFF
--- a/src/routes/reptes/me/+page.svelte
+++ b/src/routes/reptes/me/+page.svelte
@@ -1,132 +1,219 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
-  import { user } from '$lib/authStore';
+import { onMount } from 'svelte';
+import { user } from '$lib/authStore';
 
-  type Challenge = {
-    id: string;
-    event_id: string;
-    tipus: 'normal' | 'access';
-    reptador_id: string;
-    reptat_id: string;
-    estat: 'proposat' | 'acceptat' | 'programat' | 'refusat' | 'caducat' | 'jugat' | 'anullat';
-    dates_proposades: string[];
-    data_proposta: string;
-    data_acceptacio: string | null;
-    pos_reptador: number | null;
-    pos_reptat: number | null;
-    reptador_nom?: string;
-    reptat_nom?: string;
-  };
+type Challenge = {
+  id: string;
+  event_id: string;
+  tipus: 'normal' | 'access';
+  reptador_id: string;
+  reptat_id: string;
+  estat: 'proposat' | 'acceptat' | 'programat' | 'refusat' | 'caducat' | 'jugat' | 'anullat';
+  dates_proposades: string[];
+  data_proposta: string;
+  data_acceptacio: string | null;
+  pos_reptador: number | null;
+  pos_reptat: number | null;
+  reptador_nom?: string;
+  reptat_nom?: string;
+};
 
-  let loading = true;
-  let error: string | null = null;     // missatge d'error
-  let okMsg: string | null = null;     // missatge d’èxit
-  let rows: Challenge[] = [];
-  let myPlayerId: string | null = null;
-  let actionBusy: string | null = null; // id del repte en acció
+let loading = true;
+let error: string | null = null;
+let okMsg: string | null = null;
+let rows: Challenge[] = [];
+let myPlayerId: string | null = null;
+let busy: string | null = null;
+let scheduleLocal: Map<string, string> = new Map();
 
-  onMount(async () => {
-    try {
-      await fetch('/reptes/penalitzacions', { method: 'POST' });
-    } catch {
-      // ignore errors
-    }
-    await load();
-  });
-
-  async function load() {
-    try {
-      loading = true;
-      error = null;
-      okMsg = null;
-
-      const u = $user;
-      if (!u?.email) {
-        error = 'Has d’iniciar sessió per veure els teus reptes.';
-        return;
-      }
-
-      const { supabase } = await import('$lib/supabaseClient');
-
-      // 1) Quin és el meu player_id?
-      const { data: p, error: e1 } = await supabase
-        .from('players')
-        .select('id')
-        .eq('email', u.email)
-        .maybeSingle();
-
-      if (e1) throw e1;
-      if (!p) {
-        error = 'El teu email no està vinculat a cap jugador.';
-        return;
-      }
-      myPlayerId = p.id;
-
-      // 2) Reptes on hi sóc (com reptador o reptat)
-      const { data: ch, error: e2 } = await supabase
-        .from('challenges')
-        .select('id,event_id,tipus,reptador_id,reptat_id,estat,dates_proposades,data_proposta,data_acceptacio,pos_reptador,pos_reptat')
-        .or(`reptador_id.eq.${myPlayerId},reptat_id.eq.${myPlayerId}`)
-        .order('data_proposta', { ascending: false });
-
-      if (e2) throw e2;
-
-      // 3) Diccionari id->nom per mostrar noms
-      const ids = Array.from(
-        new Set([...(ch?.map(c => c.reptador_id) ?? []), ...(ch?.map(c => c.reptat_id) ?? [])])
-      );
-
-      let nameById = new Map<string, string>();
-      if (ids.length) {
-        const { data: players, error: e3 } = await supabase
-          .from('players')
-          .select('id,nom')
-          .in('id', ids);
-        if (e3) throw e3;
-        nameById = new Map(players?.map(p => [p.id, p.nom]) ?? []);
-      }
-
-      rows = (ch ?? []).map(c => ({
-        ...c,
-        reptador_nom: nameById.get(c.reptador_id) ?? '—',
-        reptat_nom: nameById.get(c.reptat_id) ?? '—'
-      }));
-    } catch (e: any) {
-      error = e?.message ?? 'Error desconegut carregant reptes';
-    } finally {
-      loading = false;
-    }
+onMount(async () => {
+  try {
+    await fetch('/reptes/penalitzacions', { method: 'POST' });
+  } catch {
+    /* ignore */
   }
+  await load();
+});
 
-  function fmt(d: string | null) {
-    if (!d) return '—';
-    try { return new Date(d).toLocaleString(); } catch { return d; }
-  }
-
-  function canRespond(r: Challenge) {
-    return myPlayerId && r.reptat_id === myPlayerId && r.estat === 'proposat';
-  }
-
-  async function respond(r: Challenge, accept: boolean) {
+async function load() {
+  try {
+    loading = true;
     error = null;
     okMsg = null;
-    try {
-      actionBusy = r.id;
-      const { supabase } = await import('$lib/supabaseClient');
-      const { error: err } = await supabase
-        .from('challenges')
-        .update({ estat: accept ? 'acceptat' : 'refusat' })
-        .eq('id', r.id);
-      if (err) throw err;
 
-      okMsg = accept ? 'Repte acceptat correctament.' : 'Repte refusat correctament.';
-      await load(); // refresca llista
-    } catch (e: any) {
-      error = e?.message ?? 'No s’ha pogut actualitzar el repte';
-    } finally {
-      actionBusy = null;
+    const u = $user;
+    if (!u?.email) {
+      error = 'Has d\u2019iniciar sessi\u00f3.';
+      return;
     }
+
+    const { supabase } = await import('$lib/supabaseClient');
+
+    const { data: p, error: e1 } = await supabase
+      .from('players')
+      .select('id')
+      .eq('email', u.email)
+      .maybeSingle();
+    if (e1) throw e1;
+    if (!p) {
+      error = 'El teu email no est\u00e0 vinculat a cap jugador.';
+      return;
+    }
+    myPlayerId = p.id;
+
+    const { data: ch, error: e2 } = await supabase
+      .from('challenges')
+      .select('id,event_id,tipus,reptador_id,reptat_id,estat,dates_proposades,data_proposta,data_acceptacio,pos_reptador,pos_reptat')
+      .or(`reptador_id.eq.${myPlayerId},reptat_id.eq.${myPlayerId}`)
+      .order('data_proposta', { ascending: false });
+    if (e2) throw e2;
+
+    const ids = Array.from(
+      new Set([...(ch?.map((c) => c.reptador_id) ?? []), ...(ch?.map((c) => c.reptat_id) ?? [])])
+    );
+    let nameById = new Map<string, string>();
+    if (ids.length) {
+      const { data: players, error: e3 } = await supabase
+        .from('players')
+        .select('id,nom')
+        .in('id', ids);
+      if (e3) throw e3;
+      nameById = new Map(players?.map((p) => [p.id, p.nom]) ?? []);
+    }
+
+    rows = (ch ?? []).map((c) => ({
+      ...c,
+      reptador_nom: nameById.get(c.reptador_id) ?? '—',
+      reptat_nom: nameById.get(c.reptat_id) ?? '—'
+    }));
+
+    scheduleLocal = new Map();
+    const now = toLocalInput(new Date().toISOString());
+    for (const r of rows) {
+      scheduleLocal.set(r.id, toLocalInput(r.data_acceptacio) || now);
+    }
+    scheduleLocal = new Map(scheduleLocal);
+  } catch (e: any) {
+    error = e?.message ?? 'Error desconegut carregant reptes';
+  } finally {
+    loading = false;
   }
+}
+
+function fmt(iso: string | null) {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  return isNaN(d.getTime()) ? iso : d.toLocaleString();
+}
+
+function toLocalInput(iso: string | null) {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return '';
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function parseLocalToIso(local: string | null) {
+  if (!local) return null;
+  const d = new Date(local);
+  return isNaN(d.getTime()) ? null : d.toISOString();
+}
+
+function isMeReptat(r: Challenge) {
+  return myPlayerId === r.reptat_id;
+}
+
+function isMeReptador(r: Challenge) {
+  return myPlayerId === r.reptador_id;
+}
+
+function canAccept(r: Challenge) {
+  return r.estat === 'proposat' && isMeReptat(r);
+}
+
+function canRefuse(r: Challenge) {
+  return r.estat === 'proposat' && isMeReptat(r);
+}
+
+function canProgram(r: Challenge) {
+  if (r.estat === 'proposat') return isMeReptat(r);
+  if (['acceptat', 'programat'].includes(r.estat)) return isMeReptat(r) || isMeReptador(r);
+  return false;
+}
+
+function isFrozen(r: Challenge) {
+  return ['anullat', 'jugat', 'refusat', 'caducat'].includes(r.estat);
+}
+
+async function accept(r: Challenge) {
+  error = null;
+  okMsg = null;
+  try {
+    busy = r.id;
+    const { supabase } = await import('$lib/supabaseClient');
+    const { error: e } = await supabase
+      .from('challenges')
+      .update({ estat: 'acceptat', data_acceptacio: null })
+      .eq('id', r.id)
+      .eq('estat', 'proposat');
+    if (e) throw e;
+    okMsg = 'Repte acceptat correctament.';
+    await load();
+  } catch (e: any) {
+    error = e?.message ?? 'No s\u2019ha pogut acceptar el repte';
+  } finally {
+    busy = null;
+  }
+}
+
+async function refuse(r: Challenge) {
+  error = null;
+  okMsg = null;
+  try {
+    busy = r.id;
+    const { supabase } = await import('$lib/supabaseClient');
+    const { error: e } = await supabase
+      .from('challenges')
+      .update({ estat: 'refusat' })
+      .eq('id', r.id)
+      .eq('estat', 'proposat');
+    if (e) throw e;
+    okMsg = 'Repte refusat correctament.';
+    await load();
+  } catch (e: any) {
+    error = e?.message ?? 'No s\u2019ha pogut refusar el repte';
+  } finally {
+    busy = null;
+  }
+}
+
+async function saveSchedule(r: Challenge) {
+  error = null;
+  okMsg = null;
+  const local = scheduleLocal.get(r.id) ?? '';
+  const iso = parseLocalToIso(local);
+  if (!iso) {
+    error = 'Cal indicar una data v\u00e0lida.';
+    return;
+  }
+  try {
+    busy = r.id;
+    const { supabase } = await import('$lib/supabaseClient');
+    const { error: e } = await supabase
+      .from('challenges')
+      .update({ data_acceptacio: iso, estat: 'programat' })
+      .eq('id', r.id)
+      .in('estat', ['proposat', 'acceptat', 'programat']);
+    if (e) throw e;
+    okMsg = 'Data desada correctament.';
+    await load();
+  } catch (e: any) {
+    error = e?.message ?? 'No s\u2019ha pogut desar la data';
+  } finally {
+    busy = null;
+  }
+}
 </script>
 
 <svelte:head>
@@ -141,7 +228,6 @@
   {#if error}
     <div class="rounded border border-red-300 bg-red-50 text-red-800 p-3 mb-3">{error}</div>
   {/if}
-
   {#if okMsg}
     <div class="rounded border border-green-300 bg-green-50 text-green-800 p-3 mb-3">{okMsg}</div>
   {/if}
@@ -153,20 +239,23 @@
   {#if rows.length > 0}
     <div class="space-y-3">
       {#each rows as r}
-        <div class="rounded border p-3">
+        <div class="rounded border p-3 space-y-2">
           <div class="flex flex-wrap items-center gap-2">
             <span class="text-xs rounded bg-slate-800 text-white px-2 py-0.5">{r.tipus}</span>
             <span class="text-xs rounded bg-slate-100 px-2 py-0.5 capitalize">{r.estat}</span>
             <span class="text-xs text-slate-500 ml-auto">Proposat: {fmt(r.data_proposta)}</span>
+            {#if r.data_acceptacio}
+              <span class="text-xs text-slate-500">Programat: {fmt(r.data_acceptacio)}</span>
+            {/if}
           </div>
 
-          <div class="mt-2 text-sm">
+          <div class="text-sm">
             <div><strong>Reptador:</strong> #{r.pos_reptador ?? '—'} — {r.reptador_nom}</div>
             <div><strong>Reptat:</strong> #{r.pos_reptat ?? '—'} — {r.reptat_nom}</div>
           </div>
 
           {#if r.dates_proposades?.length}
-            <div class="mt-2 text-sm">
+            <div class="text-sm">
               <strong>Dates proposades:</strong>
               <ul class="list-disc ml-6">
                 {#each r.dates_proposades as d}<li>{fmt(d)}</li>{/each}
@@ -174,23 +263,51 @@
             </div>
           {/if}
 
-          {#if canRespond(r)}
-            <div class="mt-3 flex gap-2">
+          {#if canAccept(r)}
+            <div class="flex gap-2 mb-2">
               <button
                 class="rounded bg-green-600 text-white px-3 py-1 disabled:opacity-60"
-                on:click={() => respond(r, true)}
-                disabled={actionBusy === r.id}
+                on:click={() => accept(r)}
+                disabled={busy === r.id}
               >
-                {actionBusy === r.id ? 'Processant…' : 'Accepta'}
+                {busy === r.id ? 'Processant…' : 'Accepta'}
               </button>
               <button
                 class="rounded bg-red-600 text-white px-3 py-1 disabled:opacity-60"
-                on:click={() => respond(r, false)}
-                disabled={actionBusy === r.id}
+                on:click={() => refuse(r)}
+                disabled={busy === r.id}
               >
-                {actionBusy === r.id ? 'Processant…' : 'Refusa'}
+                {busy === r.id ? 'Processant…' : 'Refusa'}
               </button>
             </div>
+          {/if}
+
+          {#if canProgram(r)}
+            <div class="flex flex-wrap items-end gap-2">
+              <div>
+                <label class="text-sm" for={`schedule-${r.id}`}>
+                  {r.estat === 'proposat' ? 'Programar' : '(Re)programar'}
+                </label>
+                <input
+                  class="block border rounded px-2 py-1 mt-1"
+                  type="datetime-local"
+                  step="60"
+                  id={`schedule-${r.id}`}
+                  value={scheduleLocal.get(r.id) ?? ''}
+                  on:input={(e) => scheduleLocal.set(r.id, (e.target as HTMLInputElement).value)}
+                  disabled={busy === r.id}
+                />
+              </div>
+              <button
+                class="rounded bg-blue-600 text-white px-3 py-1 h-9 disabled:opacity-60"
+                on:click={() => saveSchedule(r)}
+                disabled={busy === r.id}
+              >
+                {busy === r.id ? 'Desant…' : 'Desa data'}
+              </button>
+            </div>
+          {:else if isFrozen(r)}
+            <div class="text-sm text-slate-500">Sense accions.</div>
           {/if}
         </div>
       {/each}


### PR DESCRIPTION
## Summary
- allow logged-in users to accept or refuse their own challenges
- enable scheduling and rescheduling with local datetime handling
- display Tailwind banners for success/error messages

## Testing
- `npm test` *(fails: Missing script)*
- `PUBLIC_SUPABASE_URL=x SUPABASE_SERVICE_ROLE_KEY=y npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68c011325830832e8f71a489a9818f84