### PR TITLE
feat(admin): add configuration screen

### DIFF
--- a/src/routes/admin/config/+page.ts
+++ b/src/routes/admin/config/+page.ts
@@ -1,2 +1,21 @@
-// Desactivem SSR per simplicitat en les crides al client
+import type { PageLoad } from './$types';
+import { supabase } from '$lib/supabaseClient';
+
 export const ssr = false;
+export const prerender = false;
+
+export const load: PageLoad = async () => {
+  const { data, error } = await supabase
+    .from('app_settings')
+    .select(
+      'id, caramboles_objectiu, max_entrades, allow_tiebreak, cooldown_min_dies, cooldown_max_dies, dies_acceptar_repte, dies_jugar_despres_acceptar, ranking_max_jugadors'
+    )
+    .order('updated_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  return {
+    settings: data ?? null,
+    loadError: error?.message ?? null
+  };
+};


### PR DESCRIPTION
## Summary
- add client-side loader for app settings
- implement admin configuration form with validation and save logic

## Testing
- `pnpm check` *(fails: A form label must be associated with a control)*

------
https://chatgpt.com/codex/tasks/task_e_68c02749de50832e90bf857b68f06f70