### PR TITLE
Load ranking via Supabase RPC

### DIFF
--- a/src/routes/classificacio/+page.svelte
+++ b/src/routes/classificacio/+page.svelte
@@ -23,15 +23,11 @@
 
   onMount(async () => {
     try {
-      // importem el client només al navegador
       const { supabase } = await import('$lib/supabaseClient');
-      const { data, error: err } = await supabase
-        .from('v_ranking')
-        .select('event_id,posicio,player_id,nom,mitjana,estat,assignat_el')
-        .order('posicio', { ascending: true });
+      const { data, error: err } = await supabase.rpc('get_ranking');
 
       if (err) error = err.message;
-      else rows = data ?? [];
+      else rows = (data as Row[]) ?? [];
     } catch (e: any) {
       error = e?.message ?? 'Error desconegut';
     } finally {
@@ -45,7 +41,9 @@
 {#if loading}
   <p class="text-slate-500">Carregant rànquing…</p>
 {:else if error}
-  <p class="text-red-600">Error: {error}</p>
+  <div class="mb-4 rounded border border-red-200 bg-red-50 p-3 text-red-700">
+    Error: {error}
+  </div>
 {:else if rows.length === 0}
   <p class="text-slate-500">Encara no hi ha posicions al rànquing.</p>
 {:else}
@@ -74,3 +72,4 @@
     </table>
   </div>
 {/if}
+


### PR DESCRIPTION
## Summary
- Fetch ranking rows with `supabase.rpc('get_ranking')` on the classificació page
- Display results in table with loading and error states

## Testing
- `pnpm check` *(fails: Module '"$env/static/public"' has no exported member 'PUBLIC_SUPABASE_URL')*


------
https://chatgpt.com/codex/tasks/task_e_68c1176236a8832e8410af8680e9b286