### PR TITLE
feat: add admin config menu and client-side guard

### DIFF
--- a/src/lib/components/Nav.svelte
+++ b/src/lib/components/Nav.svelte
@@ -66,11 +66,21 @@
           <li>
             <a
               href="/admin"
-              class="px-2 py-1 rounded hover:bg-slate-100"
-              class:bg-slate-900={isActive('/admin')}
-              class:text-white={isActive('/admin')}
+              class="px-2 py-1 rounded hover:bg-slate-100 hover:underline"
+              class:bg-slate-900={isActive('/admin') && !$page.url.pathname.startsWith('/admin/config')}
+              class:text-white={isActive('/admin') && !$page.url.pathname.startsWith('/admin/config')}
             >
               Admin
+            </a>
+          </li>
+          <li>
+            <a
+              href="/admin/config"
+              class="px-2 py-1 rounded hover:bg-slate-100 hover:underline"
+              class:bg-slate-900={isActive('/admin/config')}
+              class:text-white={isActive('/admin/config')}
+            >
+              Configuració
             </a>
           </li>
         {/if}
@@ -140,12 +150,23 @@
           <li>
             <a
               href="/admin"
-              class="block px-2 py-2 rounded hover:bg-slate-100"
-              class:bg-slate-900={isActive('/admin')}
-              class:text-white={isActive('/admin')}
+              class="block px-2 py-2 rounded hover:bg-slate-100 hover:underline"
+              class:bg-slate-900={isActive('/admin') && !$page.url.pathname.startsWith('/admin/config')}
+              class:text-white={isActive('/admin') && !$page.url.pathname.startsWith('/admin/config')}
               on:click={() => (open = false)}
             >
               Admin
+            </a>
+          </li>
+          <li>
+            <a
+              href="/admin/config"
+              class="block px-2 py-2 rounded hover:bg-slate-100 hover:underline"
+              class:bg-slate-900={isActive('/admin/config')}
+              class:text-white={isActive('/admin/config')}
+              on:click={() => (open = false)}
+            >
+              Configuració
             </a>
           </li>
         {/if}

--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { isAdmin } from '$lib/authStore';
+
+  let admin = false;
+  let checked = false;
+
+  onMount(() => {
+    const unsub = isAdmin.subscribe((v) => {
+      admin = v;
+      checked = true;
+    });
+    return unsub;
+  });
+</script>
+
+{#if admin}
+  <slot />
+{:else if checked}
+  <div class="m-4 rounded border border-red-300 bg-red-50 p-4 text-red-800">
+    No autoritzat — <a href="/" class="underline">Inici</a>
+  </div>
+{/if}
+


### PR DESCRIPTION
## Summary
- add Configuració link alongside Admin in navigation for admin users
- guard admin routes on the client, showing a friendly unauthorized banner

## Testing
- `pnpm check` *(fails: Type 'AppSettings | null' is not assignable to type 'AppSettings'; Module "$env/static/public" has no exported member 'PUBLIC_SUPABASE_URL'; etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68c118794f88832e968b83e08e98871b