### PR TITLE
refactor: load settings via page data

### DIFF
--- a/src/routes/reptes/me/+page.svelte
+++ b/src/routes/reptes/me/+page.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
 import { onMount } from 'svelte';
 import { user } from '$lib/authStore';
-import { getSettings, type AppSettings } from '$lib/settings';
+import type { AppSettings } from '$lib/settings';
+
+export let data: { settings: AppSettings };
+let settings: AppSettings = data.settings;
 
 type Challenge = {
   id: string;
@@ -27,7 +30,6 @@ let rows: Challenge[] = [];
 let myPlayerId: string | null = null;
 let busy: string | null = null;
 let scheduleLocal: Map<string, string> = new Map();
-let settings: AppSettings = await getSettings();
 
 onMount(async () => {
   try {

--- a/src/routes/reptes/me/+page.ts
+++ b/src/routes/reptes/me/+page.ts
@@ -4,7 +4,6 @@ import type { AppSettings } from '$lib/settings';
 import { getSettings } from '$lib/settings';
 
 export const load: PageLoad = async () => {
-  // Carrega la configuració (client-friendly; getSettings ja fa import dinàmic)
   const settings: AppSettings = await getSettings();
 
   return {


### PR DESCRIPTION
## Summary
- load settings in `+page.ts` and return via `load`
- consume settings from `data` in `me` challenges page

## Testing
- `pnpm check` *(fails: missing AppSettings and env values in other modules)*

------
https://chatgpt.com/codex/tasks/task_e_68c11e714cb8832e91d8e690b28bcb46