### PR TITLE
feat: add penalties diagnostics and insertion endpoint

### DIFF
--- a/src/routes/reptes/penalitzacions/+server.ts
+++ b/src/routes/reptes/penalitzacions/+server.ts
@@ -1,3 +1,4 @@
+// src/routes/reptes/penalitzacions/+server.ts
 import type { RequestHandler } from './$types';
 import { json } from '@sveltejs/kit';
 import { serverSupabase } from '$lib/server/supabaseAdmin';
@@ -6,63 +7,47 @@ import { getSupabaseEnv } from '$lib/server/env';
 type PenalitzacioPayload = {
   event_id: string;
   player_id: string;
-  tipus: string; // ex: 'incompareixenca' | 'no_acord_dates' | ...
-  detalls?: string;
+  tipus: string;   // 'incompareixenca' | 'no_acord_dates' | ...
+  detalls?: string | null;
 };
+
+function mkRls403() {
+  return json({ ok: false, error: 'Només administradors poden crear penalitzacions' }, { status: 403 });
+}
 
 export const GET: RequestHandler = async () => {
   const notes: string[] = [];
-  let env_ok = false;
+  let env_ok = true;
   let can_select_admins = false;
 
   try {
-    getSupabaseEnv();
-    env_ok = true;
-  } catch (e: any) {
-    notes.push(e?.message ?? 'Falta configuració de Supabase');
+    // Només comprovem existència, no revel·lem claus
+    const { url, key } = getSupabaseEnv();
+    if (!url || !key) env_ok = false;
+  } catch (e:any) {
+    env_ok = false;
+    notes.push(e?.message ?? 'No .env / PUBLIC_ variables');
   }
 
-  if (env_ok) {
-    try {
-      const supabase = serverSupabase();
-      const { error } = await supabase.from('admins').select('1').limit(1);
-      if (!error) {
-        can_select_admins = true;
-      } else {
-        const msg = String(error.message || '').toLowerCase();
-        if (
-          msg.includes('permission') ||
-          msg.includes('policy') ||
-          msg.includes('row-level security')
-        ) {
-          notes.push('RLS/permission denied a admins');
-        } else if (error.code === '42P01') {
-          notes.push('taula admins no existeix');
-        } else {
-          notes.push(error.message);
-        }
-      }
-    } catch (e: any) {
-      notes.push(e?.message ?? 'Error consultant admins');
-    }
+  try {
+    const supabase = serverSupabase();
+    const { error } = await supabase.from('admins').select('email', { count: 'exact', head: true }).limit(1);
+    if (!error) can_select_admins = true;
+    else notes.push(`admins select error: ${error.message}`);
+  } catch (e:any) {
+    notes.push(`admins select exception: ${e?.message ?? e}`);
   }
 
   return json({ env_ok, can_select_admins, notes });
 };
 
 export const POST: RequestHandler = async ({ request }) => {
-  let body: PenalitzacioPayload;
   try {
-    body = (await request.json()) as PenalitzacioPayload;
-  } catch {
-    return json({ ok: false, error: 'JSON invàlid' }, { status: 400 });
-  }
+    const body = (await request.json()) as PenalitzacioPayload;
+    if (!body?.event_id || !body?.player_id || !body?.tipus) {
+      return json({ ok: false, error: 'Falten camps obligatoris (event_id, player_id, tipus)' }, { status: 400 });
+    }
 
-  if (!body.event_id || !body.player_id || !body.tipus) {
-    return json({ ok: false, error: 'Falten camps obligatoris' }, { status: 400 });
-  }
-
-  try {
     const supabase = serverSupabase();
     const { error } = await supabase.from('penalties').insert({
       event_id: body.event_id,
@@ -74,35 +59,21 @@ export const POST: RequestHandler = async ({ request }) => {
     if (error) {
       const msg = String(error.message || '').toLowerCase();
       if (msg.includes('row-level security') || msg.includes('permission') || msg.includes('policy')) {
-        return json(
-          { ok: false, error: 'Només administradors poden crear penalitzacions' },
-          { status: 403 }
-        );
+        return mkRls403();
       }
-
-      const code = error.code;
+      const code = (error as any).code;
+      const detail = (error as any).details || (error as any).detail;
       if (code === '42P01' || code === '42703') {
-        return json(
-          { ok: false, error: error.message, code, detail: error.details ?? error.hint ?? null },
-          { status: 500 }
-        );
+        return json({ ok: false, error: 'Configuració de taula/columnes', code, detail }, { status: 500 });
       }
-
       if (code === '23503' || code === '23505') {
-        return json(
-          { ok: false, error: error.details ?? error.message, code },
-          { status: 400 }
-        );
+        return json({ ok: false, error: 'Validació de dades', code, detail }, { status: 400 });
       }
-
-      return json(
-        { ok: false, error: error.message, code, hint: error.hint, detail: error.details },
-        { status: 500 }
-      );
+      return json({ ok: false, error: error.message, code, detail, hint: (error as any).hint }, { status: 500 });
     }
 
     return json({ ok: true }, { status: 201 });
-  } catch (e: any) {
+  } catch (e:any) {
     return json({ ok: false, error: e?.message ?? 'Error intern' }, { status: 500 });
   }
 };


### PR DESCRIPTION
## Summary
- implement GET diagnostics for penalties route
- handle penalties insertion with Supabase and explicit error mapping

## Testing
- `pnpm run check` *(fails: module exports and settings type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c153d8176c832e86282d31feca0a05