### PR TITLE
Forward Authorization header for penalties endpoint

### DIFF
--- a/src/lib/server/supabaseAdmin.ts
+++ b/src/lib/server/supabaseAdmin.ts
@@ -1,9 +1,20 @@
+// src/lib/server/supabaseAdmin.ts
 import { createClient } from '@supabase/supabase-js';
 import { getSupabaseEnv } from './env';
 
-export function serverSupabase() {
+export function serverSupabase(req?: Request) {
   const { url, key } = getSupabaseEnv();
+
+  const authHeader =
+    req?.headers.get('authorization') ||
+    req?.headers.get('Authorization') ||
+    null;
+
   return createClient(url, key, {
-    auth: { persistSession: false, autoRefreshToken: false }
+    auth: { persistSession: false, autoRefreshToken: false },
+    global: {
+      headers: authHeader ? { Authorization: authHeader } : {}
+    }
   });
 }
+

--- a/src/routes/reptes/+page.svelte
+++ b/src/routes/reptes/+page.svelte
@@ -4,7 +4,19 @@
 
   onMount(async () => {
     try {
-      await fetch('/reptes/penalitzacions', { method: 'POST' });
+      const { supabase } = await import('$lib/supabaseClient');
+      const { data: sessionData } = await supabase.auth.getSession();
+      const token = sessionData?.session?.access_token;
+      if (token) {
+        await fetch('/reptes/penalitzacions', {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            authorization: `Bearer ${token}`
+          },
+          body: JSON.stringify({})
+        });
+      }
     } catch {
       // ignore errors applying penalties
     }

--- a/src/routes/reptes/me/+page.svelte
+++ b/src/routes/reptes/me/+page.svelte
@@ -33,7 +33,19 @@ let scheduleLocal: Map<string, string> = new Map();
 
 onMount(async () => {
   try {
-    await fetch('/reptes/penalitzacions', { method: 'POST' });
+    const { supabase } = await import('$lib/supabaseClient');
+    const { data: sessionData } = await supabase.auth.getSession();
+    const token = sessionData?.session?.access_token;
+    if (token) {
+      await fetch('/reptes/penalitzacions', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${token}`
+        },
+        body: JSON.stringify({})
+      });
+    }
   } catch {
     /* ignore */
   }

--- a/src/routes/reptes/penalitzacions/+server.ts
+++ b/src/routes/reptes/penalitzacions/+server.ts
@@ -7,34 +7,47 @@ import { getSupabaseEnv } from '$lib/server/env';
 type PenalitzacioPayload = {
   event_id: string;
   player_id: string;
-  tipus: string;   // 'incompareixenca' | 'no_acord_dates' | ...
+  tipus: string; // 'incompareixenca' | 'no_acord_dates' | ...
   detalls?: string | null;
 };
 
 function mkRls403() {
-  return json({ ok: false, error: 'Només administradors poden crear penalitzacions' }, { status: 403 });
+  return json(
+    { ok: false, error: 'Només administradors poden crear penalitzacions' },
+    { status: 403 }
+  );
 }
 
-export const GET: RequestHandler = async () => {
+export const GET: RequestHandler = async ({ request }) => {
   const notes: string[] = [];
   let env_ok = true;
   let can_select_admins = false;
 
   try {
-    // Només comprovem existència, no revel·lem claus
     const { url, key } = getSupabaseEnv();
     if (!url || !key) env_ok = false;
-  } catch (e:any) {
+  } catch (e: any) {
     env_ok = false;
     notes.push(e?.message ?? 'No .env / PUBLIC_ variables');
   }
 
   try {
-    const supabase = serverSupabase();
-    const { error } = await supabase.from('admins').select('email', { count: 'exact', head: true }).limit(1);
-    if (!error) can_select_admins = true;
-    else notes.push(`admins select error: ${error.message}`);
-  } catch (e:any) {
+    const supabase = serverSupabase(request); // ← porta Authorization si n’hi ha
+    // Només considerem el check si hi ha Authorization; si no, no exposem res
+    const hasAuth = !!(
+      request.headers.get('authorization') || request.headers.get('Authorization')
+    );
+    if (hasAuth) {
+      const { error } = await supabase
+        .from('admins')
+        .select('email', { count: 'exact', head: true })
+        .limit(1);
+      if (!error) can_select_admins = true;
+      else notes.push(`admins select error: ${error.message || '(sense missatge)'}`);
+    } else {
+      notes.push('sense Authorization: no comprovem admins (esperat en diagnòstic públic)');
+    }
+  } catch (e: any) {
     notes.push(`admins select exception: ${e?.message ?? e}`);
   }
 
@@ -45,10 +58,16 @@ export const POST: RequestHandler = async ({ request }) => {
   try {
     const body = (await request.json()) as PenalitzacioPayload;
     if (!body?.event_id || !body?.player_id || !body?.tipus) {
-      return json({ ok: false, error: 'Falten camps obligatoris (event_id, player_id, tipus)' }, { status: 400 });
+      return json(
+        {
+          ok: false,
+          error: 'Falten camps obligatoris (event_id, player_id, tipus)'
+        },
+        { status: 400 }
+      );
     }
 
-    const supabase = serverSupabase();
+    const supabase = serverSupabase(request); // ← porta Authorization de l’usuari
     const { error } = await supabase.from('penalties').insert({
       event_id: body.event_id,
       player_id: body.player_id,
@@ -58,22 +77,35 @@ export const POST: RequestHandler = async ({ request }) => {
 
     if (error) {
       const msg = String(error.message || '').toLowerCase();
-      if (msg.includes('row-level security') || msg.includes('permission') || msg.includes('policy')) {
+      if (
+        msg.includes('row-level security') ||
+        msg.includes('permission') ||
+        msg.includes('policy')
+      ) {
         return mkRls403();
       }
       const code = (error as any).code;
       const detail = (error as any).details || (error as any).detail;
       if (code === '42P01' || code === '42703') {
-        return json({ ok: false, error: 'Configuració de taula/columnes', code, detail }, { status: 500 });
+        return json(
+          { ok: false, error: 'Configuració de taula/columnes', code, detail },
+          { status: 500 }
+        );
       }
       if (code === '23503' || code === '23505') {
-        return json({ ok: false, error: 'Validació de dades', code, detail }, { status: 400 });
+        return json(
+          { ok: false, error: 'Validació de dades', code, detail },
+          { status: 400 }
+        );
       }
-      return json({ ok: false, error: error.message, code, detail, hint: (error as any).hint }, { status: 500 });
+      return json(
+        { ok: false, error: error.message, code, detail, hint: (error as any).hint },
+        { status: 500 }
+      );
     }
 
     return json({ ok: true }, { status: 201 });
-  } catch (e:any) {
+  } catch (e: any) {
     return json({ ok: false, error: e?.message ?? 'Error intern' }, { status: 500 });
   }
 };


### PR DESCRIPTION
## Summary
- forward client Authorization headers to Supabase in server-side helper
- enforce user session for /reptes/penalitzacions GET and POST
- send Authorization tokens from client pages when triggering penalties

## Testing
- `pnpm check` *(fails: svelte-check found 6 errors and 5 warnings in 4 files)*

------
https://chatgpt.com/codex/tasks/task_e_68c1578549a0832ead3206f1b9d576fc