### PR TITLE
Fix top-level await in admin challenge result page

### DIFF
--- a/src/routes/admin/reptes/[id]/resultat/+page.svelte
+++ b/src/routes/admin/reptes/[id]/resultat/+page.svelte
@@ -2,7 +2,7 @@
   import { onMount } from 'svelte';
   import { page } from '$app/stores';
   import { user, isAdmin } from '$lib/authStore';
-  import { getSettings, type AppSettings } from '$lib/settings';
+  import type { AppSettings } from '$lib/settings';
 
   type Challenge = {
     id: string;
@@ -24,7 +24,8 @@
   let reptadorNom = '—';
   let reptatNom = '—';
 
-  let settings: AppSettings = await getSettings();
+  export let data: { settings: AppSettings };
+  let settings: AppSettings = data.settings;
 
   // Formulari
   let carR: number | '' = 0;

--- a/src/routes/admin/reptes/[id]/resultat/+page.ts
+++ b/src/routes/admin/reptes/[id]/resultat/+page.ts
@@ -1,2 +1,11 @@
 // src/routes/admin/reptes/[id]/resultat/+page.ts
+import type { PageLoad } from './$types';
+import type { AppSettings } from '$lib/settings';
+import { getSettings } from '$lib/settings';
+
 export const ssr = false;
+
+export const load: PageLoad = async () => {
+  const settings: AppSettings = await getSettings();
+  return { settings };
+};


### PR DESCRIPTION
## Summary
- Load application settings in admin challenge result page via SvelteKit `load`
- Pass settings data into component to avoid top-level `await`

## Testing
- `pnpm check` *(fails: Type 'AppSettings | null' is not assignable to type 'AppSettings'; SUPABASE_URL env not exported)*
- `pnpm build` *(fails: A form label must be associated with a control; SUPABASE_URL is not exported by virtual env)*

------
https://chatgpt.com/codex/tasks/task_e_68c15a6779ac832eade7de113202bb4a