### PR TITLE
Handle missing body in penalizations endpoint

### DIFF
--- a/src/routes/reptes/+page.svelte
+++ b/src/routes/reptes/+page.svelte
@@ -4,7 +4,7 @@
 
   onMount(async () => {
     try {
-      await fetch('/reptes/penalitzacions', { method: 'POST' });
+      await fetch('/reptes/penalitzacions');
     } catch {
       // ignore errors applying penalties
     }

--- a/src/routes/reptes/me/+page.svelte
+++ b/src/routes/reptes/me/+page.svelte
@@ -32,7 +32,7 @@ let settings: AppSettings = data.settings;
 
 onMount(async () => {
   try {
-    await fetch('/reptes/penalitzacions', { method: 'POST' });
+    await fetch('/reptes/penalitzacions');
   } catch {
     /* ignore */
   }

--- a/src/routes/reptes/penalitzacions/+server.ts
+++ b/src/routes/reptes/penalitzacions/+server.ts
@@ -43,9 +43,19 @@ export const GET: RequestHandler = async () => {
 
 export const POST: RequestHandler = async ({ request }) => {
   try {
-    const body = (await request.json()) as PenalitzacioPayload;
-    if (!body?.event_id || !body?.player_id || !body?.tipus) {
-      return json({ ok: false, error: 'Falten camps obligatoris (event_id, player_id, tipus)' }, { status: 400 });
+    let body: PenalitzacioPayload | null = null;
+    try {
+      body = (await request.json()) as PenalitzacioPayload;
+    } catch {
+      // body missing or invalid JSON
+      return json({ ok: false, error: 'Cos JSON requerit' }, { status: 400 });
+    }
+
+    if (!body || !body.event_id || !body.player_id || !body.tipus) {
+      return json(
+        { ok: false, error: 'Falten camps obligatoris (event_id, player_id, tipus)' },
+        { status: 400 }
+      );
     }
 
     const supabase = serverSupabase();
@@ -73,7 +83,7 @@ export const POST: RequestHandler = async ({ request }) => {
     }
 
     return json({ ok: true }, { status: 201 });
-  } catch (e:any) {
+  } catch (e: any) {
     return json({ ok: false, error: e?.message ?? 'Error intern' }, { status: 500 });
   }
 };


### PR DESCRIPTION
## Summary
- Guard `/reptes/penalitzacions` POST handler against empty or invalid JSON bodies
- Switch `/reptes` pages to use GET request for penalty diagnostics

## Testing
- `npm run check` *(fails: svelte-check found 6 errors and 5 warnings)*
- `node <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68c15e97da04832e9e08eb016a78c248