### PR TITLE
feat: add admin penalties page

### DIFF
--- a/src/lib/components/Nav.svelte
+++ b/src/lib/components/Nav.svelte
@@ -67,8 +67,16 @@
             <a
               href="/admin"
               class="px-2 py-1 rounded hover:bg-slate-100 hover:underline"
-              class:bg-slate-900={isActive('/admin') && !$page.url.pathname.startsWith('/admin/config')}
-              class:text-white={isActive('/admin') && !$page.url.pathname.startsWith('/admin/config')}
+              class:bg-slate-900={
+                isActive('/admin') &&
+                !$page.url.pathname.startsWith('/admin/config') &&
+                !$page.url.pathname.startsWith('/admin/penalitzacions')
+              }
+              class:text-white={
+                isActive('/admin') &&
+                !$page.url.pathname.startsWith('/admin/config') &&
+                !$page.url.pathname.startsWith('/admin/penalitzacions')
+              }
             >
               Admin
             </a>
@@ -81,6 +89,16 @@
               class:text-white={isActive('/admin/config')}
             >
               Configuració
+            </a>
+          </li>
+          <li>
+            <a
+              href="/admin/penalitzacions"
+              class="px-2 py-1 rounded hover:bg-slate-100 hover:underline"
+              class:bg-slate-900={isActive('/admin/penalitzacions')}
+              class:text-white={isActive('/admin/penalitzacions')}
+            >
+              Penalitzacions
             </a>
           </li>
         {/if}
@@ -151,8 +169,16 @@
             <a
               href="/admin"
               class="block px-2 py-2 rounded hover:bg-slate-100 hover:underline"
-              class:bg-slate-900={isActive('/admin') && !$page.url.pathname.startsWith('/admin/config')}
-              class:text-white={isActive('/admin') && !$page.url.pathname.startsWith('/admin/config')}
+              class:bg-slate-900={
+                isActive('/admin') &&
+                !$page.url.pathname.startsWith('/admin/config') &&
+                !$page.url.pathname.startsWith('/admin/penalitzacions')
+              }
+              class:text-white={
+                isActive('/admin') &&
+                !$page.url.pathname.startsWith('/admin/config') &&
+                !$page.url.pathname.startsWith('/admin/penalitzacions')
+              }
               on:click={() => (open = false)}
             >
               Admin
@@ -167,6 +193,17 @@
               on:click={() => (open = false)}
             >
               Configuració
+            </a>
+          </li>
+          <li>
+            <a
+              href="/admin/penalitzacions"
+              class="block px-2 py-2 rounded hover:bg-slate-100 hover:underline"
+              class:bg-slate-900={isActive('/admin/penalitzacions')}
+              class:text-white={isActive('/admin/penalitzacions')}
+              on:click={() => (open = false)}
+            >
+              Penalitzacions
             </a>
           </li>
         {/if}

--- a/src/routes/admin/penalitzacions/+page.svelte
+++ b/src/routes/admin/penalitzacions/+page.svelte
@@ -1,0 +1,153 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { user } from '$lib/authStore';
+  import { isAdmin as checkAdmin } from '$lib/isAdmin';
+
+  type Event = { id: string; nom: string };
+  type Player = { id: string; nom: string };
+
+  let loading = true;
+  let unauthorized = false;
+  let error: string | null = null;
+  let okMsg: string | null = null;
+  let busy = false;
+
+  let events: Event[] = [];
+  let players: Player[] = [];
+  let event_id = '';
+  let player_id = '';
+  let tipus: string = 'incompareixenca';
+  let detalls = '';
+
+  onMount(async () => {
+    const u = $user;
+    if (!u?.email) {
+      unauthorized = true;
+      loading = false;
+      return;
+    }
+    const adm = await checkAdmin();
+    if (!adm) {
+      unauthorized = true;
+      loading = false;
+      return;
+    }
+    try {
+      const { supabase } = await import('$lib/supabaseClient');
+      const { data: ev, error: eEv } = await supabase
+        .from('events')
+        .select('id, nom')
+        .eq('actiu', true)
+        .order('creat_el', { ascending: false });
+      if (eEv) throw eEv;
+      events = ev ?? [];
+      if (events.length > 0) event_id = events[0].id;
+
+      const { data: pl, error: ePl } = await supabase
+        .from('players')
+        .select('id, nom')
+        .order('nom', { ascending: true });
+      if (ePl) throw ePl;
+      players = pl ?? [];
+      if (players.length > 0) player_id = players[0].id;
+    } catch (e: any) {
+      error = e?.message ?? 'Error carregant dades';
+    } finally {
+      loading = false;
+    }
+  });
+
+  async function save() {
+    try {
+      busy = true;
+      error = null;
+      okMsg = null;
+      const { supabase } = await import('$lib/supabaseClient');
+      const { data } = await supabase.auth.getSession();
+      const token = data?.session?.access_token;
+      const res = await fetch('/reptes/penalitzacions', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: 'Bearer ' + token
+        },
+        body: JSON.stringify({ event_id, player_id, tipus, detalls: detalls || null })
+      });
+      const js = await res.json();
+      if (!res.ok) throw new Error(js.error || 'Error creant penalització');
+      okMsg = 'Penalització creada';
+      tipus = 'incompareixenca';
+      detalls = '';
+    } catch (e: any) {
+      error = e?.message ?? 'Error creant penalització';
+    } finally {
+      busy = false;
+    }
+  }
+</script>
+
+<svelte:head>
+  <title>Admin · Penalitzacions</title>
+</svelte:head>
+
+<div class="max-w-2xl mx-auto">
+  <h1 class="text-2xl font-semibold mb-4">Penalitzacions</h1>
+
+  {#if unauthorized}
+    <div class="rounded border border-red-300 bg-red-50 p-3 text-red-700">No autoritzat</div>
+  {:else if loading}
+    <p class="text-slate-500">Carregant…</p>
+  {:else}
+    {#if error}
+      <div class="mb-4 rounded border border-red-300 bg-red-50 p-3 text-red-700">{error}</div>
+    {/if}
+    {#if okMsg}
+      <div class="mb-4 rounded border border-green-300 bg-green-50 p-3 text-green-700">{okMsg}</div>
+    {/if}
+
+    <div class="rounded-2xl border bg-white p-6 shadow-sm">
+      <form class="space-y-4" on:submit|preventDefault={save}>
+        <div>
+          <label class="block mb-1 text-sm">Event</label>
+          <select bind:value={event_id} class="w-full rounded-xl border px-3 py-2">
+            {#each events as e}
+              <option value={e.id}>{e.nom}</option>
+            {/each}
+          </select>
+        </div>
+
+        <div>
+          <label class="block mb-1 text-sm">Jugador</label>
+          <select bind:value={player_id} class="w-full rounded-xl border px-3 py-2">
+            {#each players as p}
+              <option value={p.id}>{p.nom}</option>
+            {/each}
+          </select>
+        </div>
+
+        <div>
+          <label class="block mb-1 text-sm">Tipus</label>
+          <select bind:value={tipus} class="w-full rounded-xl border px-3 py-2">
+            <option value="incompareixenca">incompareixenca</option>
+            <option value="no_acord_dates">no_acord_dates</option>
+            <option value="altres">altres</option>
+          </select>
+        </div>
+
+        <div>
+          <label class="block mb-1 text-sm">Detalls (opcional)</label>
+          <textarea bind:value={detalls} class="w-full rounded-xl border px-3 py-2" rows="3"></textarea>
+        </div>
+
+        <button
+          type="submit"
+          class="rounded-xl bg-slate-900 px-4 py-2 text-white disabled:opacity-50"
+          disabled={busy}
+        >
+          {#if busy}Desant…{:else}Desa{/if}
+        </button>
+      </form>
+    </div>
+  {/if}
+</div>
+


### PR DESCRIPTION
## Summary
- add admin route to create player penalties
- expose penalties link in admin navigation

## Testing
- `pnpm check` *(fails: svelte-check found 5 errors and 9 warnings in 4 files)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b1f670d8832ea5559c1318c29555