### PR TITLE
feat: add admin diagnostic endpoint

### DIFF
--- a/src/routes/api/admin-test/+server.ts
+++ b/src/routes/api/admin-test/+server.ts
@@ -1,0 +1,23 @@
+// src/routes/api/admin-test/+server.ts
+import type { RequestHandler } from './$types';
+import { json } from '@sveltejs/kit';
+import { serverSupabase } from '$lib/server/supabaseAdmin';
+
+export const GET: RequestHandler = async ({ request }) => {
+  try {
+    const supabase = serverSupabase(request); // passa Authorization cap a Supabase
+    const { data: session, error: sErr } = await supabase.auth.getUser();
+    const who = session?.user?.email ?? null;
+    const { data, error } = await supabase
+      .from('admins')
+      .select('email')
+      .maybeSingle();
+    return json({
+      who,
+      admin_row: data ?? null,
+      error: error?.message ?? null
+    });
+  } catch (e: any) {
+    return json({ who: null, admin_row: null, error: e?.message ?? 'error' }, { status: 500 });
+  }
+};


### PR DESCRIPTION
## Summary
- add `/api/admin-test` diagnostic endpoint to check admin recognition through RLS

## Testing
- `pnpm run check` *(fails: svelte-check found 5 errors and 9 warnings in 4 files)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e2863244832eade8b2e2c10bf36d