### PR TITLE
chore: fix label associations for accessibility

### DIFF
--- a/src/routes/admin/penalitzacions/+page.svelte
+++ b/src/routes/admin/penalitzacions/+page.svelte
@@ -108,8 +108,8 @@
     <div class="rounded-2xl border bg-white p-6 shadow-sm">
       <form class="space-y-4" on:submit|preventDefault={save}>
         <div>
-          <label class="block mb-1 text-sm">Event</label>
-          <select bind:value={event_id} class="w-full rounded-xl border px-3 py-2">
+          <label for="event" class="block mb-1 text-sm">Event</label>
+          <select id="event" bind:value={event_id} class="w-full rounded-xl border px-3 py-2">
             {#each events as e}
               <option value={e.id}>{e.nom}</option>
             {/each}
@@ -117,8 +117,8 @@
         </div>
 
         <div>
-          <label class="block mb-1 text-sm">Jugador</label>
-          <select bind:value={player_id} class="w-full rounded-xl border px-3 py-2">
+          <label for="player" class="block mb-1 text-sm">Jugador</label>
+          <select id="player" bind:value={player_id} class="w-full rounded-xl border px-3 py-2">
             {#each players as p}
               <option value={p.id}>{p.nom}</option>
             {/each}
@@ -126,8 +126,8 @@
         </div>
 
         <div>
-          <label class="block mb-1 text-sm">Tipus</label>
-          <select bind:value={tipus} class="w-full rounded-xl border px-3 py-2">
+          <label for="tipus" class="block mb-1 text-sm">Tipus</label>
+          <select id="tipus" bind:value={tipus} class="w-full rounded-xl border px-3 py-2">
             <option value="incompareixenca">incompareixenca</option>
             <option value="no_acord_dates">no_acord_dates</option>
             <option value="altres">altres</option>
@@ -135,8 +135,8 @@
         </div>
 
         <div>
-          <label class="block mb-1 text-sm">Detalls (opcional)</label>
-          <textarea bind:value={detalls} class="w-full rounded-xl border px-3 py-2" rows="3"></textarea>
+          <label for="detalls" class="block mb-1 text-sm">Detalls (opcional)</label>
+          <textarea id="detalls" bind:value={detalls} class="w-full rounded-xl border px-3 py-2" rows="3"></textarea>
         </div>
 
         <button

--- a/src/routes/admin/reptes/[id]/resultat/+page.svelte
+++ b/src/routes/admin/reptes/[id]/resultat/+page.svelte
@@ -287,29 +287,29 @@
           <div class="rounded-2xl border bg-white p-4 shadow-sm">
             <div class="text-xs uppercase tracking-wide text-slate-500 mb-2">Caràmboles</div>
             <div class="grid grid-cols-1 gap-3">
-              <label class="grid gap-1">
-                <span class="text-sm text-slate-700">Reptador</span>
-                <input type="number" min="0" max={settings.caramboles_objectiu}
+              <div class="grid gap-1">
+                <label for="carR" class="text-sm text-slate-700">Reptador</label>
+                <input id="carR" type="number" min="0" max={settings.caramboles_objectiu}
                        class="rounded-xl border px-3 py-2"
                        bind:value={carR}/>
-              </label>
-              <label class="grid gap-1">
-                <span class="text-sm text-slate-700">Reptat</span>
-                <input type="number" min="0" max={settings.caramboles_objectiu}
+              </div>
+              <div class="grid gap-1">
+                <label for="carT" class="text-sm text-slate-700">Reptat</label>
+                <input id="carT" type="number" min="0" max={settings.caramboles_objectiu}
                        class="rounded-xl border px-3 py-2"
                        bind:value={carT}/>
-              </label>
+              </div>
             </div>
           </div>
 
           <div class="rounded-2xl border bg-white p-4 shadow-sm">
             <div class="text-xs uppercase tracking-wide text-slate-500 mb-2">Entrades i Tie-break</div>
-            <label class="grid gap-1">
-              <span class="text-sm text-slate-700">Entrades (total)</span>
-              <input type="number" min="0" max={settings.max_entrades}
+            <div class="grid gap-1">
+              <label for="entrades" class="text-sm text-slate-700">Entrades (total)</label>
+              <input id="entrades" type="number" min="0" max={settings.max_entrades}
                      class="rounded-xl border px-3 py-2"
                      bind:value={entrades}/>
-            </label>
+            </div>
             <div class="mt-4 flex items-center gap-2">
               <input id="tiebreak" type="checkbox" class="rounded border" bind:checked={tiebreak} disabled={!settings.allow_tiebreak} />
               <label for="tiebreak" class="text-sm">Hi ha hagut tie-break</label>
@@ -317,14 +317,14 @@
 
             {#if tiebreak}
               <div class="mt-3 grid grid-cols-2 gap-3">
-                <label class="grid gap-1">
-                  <span class="text-sm text-slate-700">Tie-break (reptador)</span>
-                  <input type="number" min="0" class="rounded-xl border px-3 py-2" bind:value={tbR} />
-                </label>
-                <label class="grid gap-1">
-                  <span class="text-sm text-slate-700">Tie-break (reptat)</span>
-                  <input type="number" min="0" class="rounded-xl border px-3 py-2" bind:value={tbT} />
-                </label>
+                <div class="grid gap-1">
+                  <label for="tbR" class="text-sm text-slate-700">Tie-break (reptador)</label>
+                  <input id="tbR" type="number" min="0" class="rounded-xl border px-3 py-2" bind:value={tbR} />
+                </div>
+                <div class="grid gap-1">
+                  <label for="tbT" class="text-sm text-slate-700">Tie-break (reptat)</label>
+                  <input id="tbT" type="number" min="0" class="rounded-xl border px-3 py-2" bind:value={tbT} />
+                </div>
               </div>
             {/if}
           </div>

--- a/src/routes/admin/reptes/nou/+page.svelte
+++ b/src/routes/admin/reptes/nou/+page.svelte
@@ -212,13 +212,13 @@
     <form class="space-y-4 max-w-2xl" on:submit={createChallenge}>
       <div class="grid sm:grid-cols-2 gap-3">
         <div>
-          <label class="block text-sm mb-1">Event actiu</label>
-          <input class="w-full rounded border px-3 py-2 bg-slate-50" value={eventActiuId} disabled />
+          <label for="event_actiu" class="block text-sm mb-1">Event actiu</label>
+          <input id="event_actiu" class="w-full rounded border px-3 py-2 bg-slate-50" value={eventActiuId} disabled />
         </div>
 
         <div>
-          <label class="block text-sm mb-1">Tipus</label>
-          <select class="w-full rounded border px-3 py-2" bind:value={tipus}>
+          <label for="tipus" class="block text-sm mb-1">Tipus</label>
+          <select id="tipus" class="w-full rounded border px-3 py-2" bind:value={tipus}>
             <option value="normal">Normal</option>
             <option value="access">Accés</option>
           </select>
@@ -227,8 +227,8 @@
 
       <div class="grid sm:grid-cols-2 gap-3">
         <div>
-          <label class="block text-sm mb-1">Reptador</label>
-          <select class="w-full rounded border px-3 py-2" bind:value={reptador_id} required>
+          <label for="reptador" class="block text-sm mb-1">Reptador</label>
+          <select id="reptador" class="w-full rounded border px-3 py-2" bind:value={reptador_id} required>
             <option value="" disabled selected>— Selecciona —</option>
             {#each ranked as r}
               <option value={r.player_id}>#{r.posicio} — {r.nom}</option>
@@ -236,8 +236,8 @@
           </select>
         </div>
         <div>
-          <label class="block text-sm mb-1">Reptat</label>
-          <select class="w-full rounded border px-3 py-2" bind:value={reptat_id} required>
+          <label for="reptat" class="block text-sm mb-1">Reptat</label>
+          <select id="reptat" class="w-full rounded border px-3 py-2" bind:value={reptat_id} required>
             <option value="" disabled selected>— Selecciona —</option>
             {#each ranked as r}
               <option value={r.player_id}>#{r.posicio} — {r.nom}</option>
@@ -248,8 +248,8 @@
 
       <div class="grid sm:grid-cols-2 gap-3">
         <div>
-          <label class="block text-sm mb-1">Estat inicial</label>
-          <select class="w-full rounded border px-3 py-2" bind:value={estat}>
+          <label for="estat" class="block text-sm mb-1">Estat inicial</label>
+          <select id="estat" class="w-full rounded border px-3 py-2" bind:value={estat}>
             <option value="proposat">Proposat</option>
             <option value="acceptat">Acceptat (programat)</option>
             <option value="refusat">Refusat</option>

--- a/src/routes/reptes/[id]/resultat/+page.svelte
+++ b/src/routes/reptes/[id]/resultat/+page.svelte
@@ -174,34 +174,35 @@
   </div>
 
   <form class="space-y-3" on:submit|preventDefault={save}>
-    <label>
-      Data joc:
-      <input type="datetime-local" bind:value={data_joc_local} class="border rounded px-2 py-1" />
-    </label>
-    <label>
-      Caràmboles reptador:
-      <input type="number" bind:value={carR} min="0" max={settings.caramboles_objectiu} />
-    </label>
-    <label>
-      Caràmboles reptat:
-      <input type="number" bind:value={carT} min="0" max={settings.caramboles_objectiu} />
-    </label>
-    <label>
-      Entrades:
-      <input type="number" bind:value={entrades} min="0" max={settings.max_entrades} />
-    </label>
-    <label>
-      <input type="checkbox" bind:checked={tiebreak} /> Hi ha hagut tie-break
-    </label>
+    <div>
+      <label for="data_joc" class="mr-2">Data joc:</label>
+      <input id="data_joc" type="datetime-local" bind:value={data_joc_local} class="border rounded px-2 py-1" />
+    </div>
+    <div>
+      <label for="carR" class="mr-2">Caràmboles reptador:</label>
+      <input id="carR" type="number" bind:value={carR} min="0" max={settings.caramboles_objectiu} />
+    </div>
+    <div>
+      <label for="carT" class="mr-2">Caràmboles reptat:</label>
+      <input id="carT" type="number" bind:value={carT} min="0" max={settings.caramboles_objectiu} />
+    </div>
+    <div>
+      <label for="entrades" class="mr-2">Entrades:</label>
+      <input id="entrades" type="number" bind:value={entrades} min="0" max={settings.max_entrades} />
+    </div>
+    <div class="flex items-center gap-2">
+      <input id="tiebreak" type="checkbox" bind:checked={tiebreak} />
+      <label for="tiebreak">Hi ha hagut tie-break</label>
+    </div>
     {#if tiebreak}
-      <label>
-        Tie-break reptador:
-        <input type="number" bind:value={tbR} min="0" />
-      </label>
-      <label>
-        Tie-break reptat:
-        <input type="number" bind:value={tbT} min="0" />
-      </label>
+      <div>
+        <label for="tbR" class="mr-2">Tie-break reptador:</label>
+        <input id="tbR" type="number" bind:value={tbR} min="0" />
+      </div>
+      <div>
+        <label for="tbT" class="mr-2">Tie-break reptat:</label>
+        <input id="tbT" type="number" bind:value={tbT} min="0" />
+      </div>
     {/if}
     <button class="bg-slate-900 text-white px-4 py-2 rounded" disabled={saving}>
       {saving ? 'Desant…' : 'Desa resultat'}

--- a/src/routes/reptes/me/+page.svelte
+++ b/src/routes/reptes/me/+page.svelte
@@ -235,9 +235,10 @@ async function refuse(r: Challenge) {
             <div class="text-sm">
               <strong>Dates proposades:</strong>
               <ul class="mt-1 space-y-1">
-                {#each r.dates_proposades as d}
+                {#each r.dates_proposades as d, i}
                   <li class="flex items-center gap-2">
                     <input
+                      id={`date-${r.id}-${i}`}
                       type="radio"
                       name={`dates-${r.id}`}
                       value={d}
@@ -247,7 +248,7 @@ async function refuse(r: Challenge) {
                         selectedDates = new Map(selectedDates);
                       }}
                     />
-                    <span>{fmt(d)}</span>
+                    <label for={`date-${r.id}-${i}`}>{fmt(d)}</label>
                   </li>
                 {/each}
               </ul>

--- a/src/routes/reptes/nou/+page.svelte
+++ b/src/routes/reptes/nou/+page.svelte
@@ -212,15 +212,15 @@
 
   <div class="rounded-2xl border bg-white p-4 shadow-sm max-w-xl">
     <div class="grid gap-4">
-      <label class="grid gap-1">
-        <span class="text-sm text-slate-700">Tria oponent (posicions permeses)</span>
-        <select class="rounded-xl border px-3 py-2" bind:value={selectedOpponent}>
+      <div class="grid gap-1">
+        <label for="opponent" class="text-sm text-slate-700">Tria oponent (posicions permeses)</label>
+        <select id="opponent" class="rounded-xl border px-3 py-2" bind:value={selectedOpponent}>
           <option value="" disabled selected>— Selecciona jugador —</option>
           {#each reptables as r}
             <option value={r.player_id}>#{r.posicio} — {r.nom}</option>
           {/each}
         </select>
-      </label>
+      </div>
 
       {#if noReptables.length}
         <details class="text-sm text-slate-700">
@@ -234,7 +234,7 @@
       {/if}
 
       <div class="grid gap-2">
-        <span class="text-sm text-slate-700">Proposa dates (mínim 1, màxim 3)</span>
+        <span id="dates-label" class="text-sm text-slate-700">Proposa dates (mínim 1, màxim 3)</span>
 
         {#each dateInputs as v, i}
           <div class="flex gap-2 items-center">
@@ -244,6 +244,7 @@
               class="flex-1 rounded-xl border px-3 py-2"
               bind:value={dateInputs[i]}
               placeholder="AAAA-MM-DDThh:mm"
+              aria-describedby="dates-label"
             />
             <button type="button"
               class="rounded border px-3 py-2 text-sm"
@@ -264,10 +265,10 @@
         </div>
       </div>
 
-      <label class="grid gap-1">
-        <span class="text-sm text-slate-700">Observacions (opcional)</span>
-        <textarea class="rounded-xl border px-3 py-2" rows="3" bind:value={notes}></textarea>
-      </label>
+      <div class="grid gap-1">
+        <label for="notes" class="text-sm text-slate-700">Observacions (opcional)</label>
+        <textarea id="notes" class="rounded-xl border px-3 py-2" rows="3" bind:value={notes}></textarea>
+      </div>
 
       {#if valMsg}
         <div class="rounded border border-amber-300 bg-amber-50 text-amber-900 p-2 text-sm">


### PR DESCRIPTION
## Summary
- link labels with corresponding inputs in forms across the app
- add aria descriptions for dynamic date fields
- label radio options for proposed dates

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: Module has no exported member errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f1e50b28832ebbcdd586e6e52ff8