### PR TITLE
feat: add reusable loader component

### DIFF
--- a/src/lib/components/Loader.svelte
+++ b/src/lib/components/Loader.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  export let text: string = 'Carregant…';
+  export let compact: boolean = false;
+</script>
+
+{#if compact}
+  <div class="flex items-center gap-2 text-slate-500">
+    <div class="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"></div>
+    <span class="text-sm">{text}</span>
+  </div>
+{:else}
+  <div class="space-y-3 rounded border p-4">
+    <div class="space-y-2 animate-pulse">
+      <div class="h-4 w-2/3 rounded bg-slate-200"></div>
+      <div class="h-4 w-full rounded bg-slate-200"></div>
+      <div class="h-4 w-5/6 rounded bg-slate-200"></div>
+    </div>
+    <p class="text-sm text-slate-500">{text}</p>
+  </div>
+{/if}
+

--- a/src/routes/admin/config/+page.svelte
+++ b/src/routes/admin/config/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { user, authReady as loadingAuth } from '$lib/authStore';
   import { isAdmin as checkAdmin } from '$lib/isAdmin';
+  import Loader from '$lib/components/Loader.svelte';
 
   type Settings = {
     id?: string;
@@ -159,7 +160,7 @@
 <h1 class="text-2xl font-semibold mb-4">Administració — Configuració</h1>
 
 {#if !$loadingAuth || loading}
-  <p class="text-slate-500">Carregant…</p>
+  <Loader />
 {:else if !$user?.email}
   <div class="rounded border border-red-300 bg-red-50 text-red-800 p-3">Has d’iniciar sessió</div>
 {:else if !admin}

--- a/src/routes/admin/reptes/+page.svelte
+++ b/src/routes/admin/reptes/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { user, isAdmin } from '$lib/authStore';
+  import Loader from '$lib/components/Loader.svelte';
 
   type ChallengeRow = {
     id: string;
@@ -290,7 +291,7 @@
 <h1 class="text-2xl font-semibold mb-4">Reptes (administració)</h1>
 
 {#if loading}
-  <div class="animate-pulse rounded border p-4 text-slate-500">Carregant…</div>
+  <Loader />
 {:else}
   {#if error}
     <div class="rounded border border-red-300 bg-red-50 text-red-800 p-3 mb-3">{error}</div>

--- a/src/routes/admin/reptes/[id]/resultat/+page.svelte
+++ b/src/routes/admin/reptes/[id]/resultat/+page.svelte
@@ -3,6 +3,7 @@
   import { page } from '$app/stores';
   import { user, isAdmin } from '$lib/authStore';
   import type { AppSettings } from '$lib/settings';
+  import Loader from '$lib/components/Loader.svelte';
 
   type Challenge = {
     id: string;
@@ -222,7 +223,7 @@
 <h1 class="text-2xl font-semibold mb-4">Posar resultat</h1>
 
 {#if loading}
-  <div class="animate-pulse rounded border p-4 text-slate-500">Carregant…</div>
+  <Loader />
 {:else}
   {#if error}
     <div class="rounded border border-red-300 bg-red-50 text-red-800 p-3 mb-4">{error}</div>

--- a/src/routes/classificacio/+page.svelte
+++ b/src/routes/classificacio/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import Loader from '$lib/components/Loader.svelte';
 
   type Row = {
     event_id: string;
@@ -39,7 +40,7 @@
 <h1 class="text-xl font-semibold mb-4">Classificació</h1>
 
 {#if loading}
-  <p class="text-slate-500">Carregant rànquing…</p>
+  <Loader text="Carregant rànquing…" />
 {:else if error}
   <div class="mb-4 rounded border border-red-200 bg-red-50 p-3 text-red-700">
     Error: {error}

--- a/src/routes/reptes/me/+page.svelte
+++ b/src/routes/reptes/me/+page.svelte
@@ -2,6 +2,7 @@
 import { onMount } from 'svelte';
 import { user } from '$lib/authStore';
 import type { AppSettings } from '$lib/settings';
+import Loader from '$lib/components/Loader.svelte';
 
 type Challenge = {
   id: string;
@@ -203,7 +204,7 @@ async function refuse(r: Challenge) {
 </div>
 
 {#if loading}
-  <p class="text-slate-500">Carregant…</p>
+  <Loader />
 {:else}
   {#if error}
     <div class="rounded border border-red-300 bg-red-50 text-red-800 p-3 mb-3">{error}</div>

--- a/src/routes/reptes/nou/+page.svelte
+++ b/src/routes/reptes/nou/+page.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import { supabase } from '$lib/supabaseClient';
   import { getSettings } from '$lib/settings';
+  import Loader from '$lib/components/Loader.svelte';
 
   type RankedPlayer = { posicio: number; player_id: string; nom: string };
   type NotReptable = RankedPlayer & { motiu: string };
@@ -199,7 +200,7 @@
 <h1 class="text-2xl font-semibold mb-4">Nou repte</h1>
 
 {#if loading}
-  <div class="rounded border p-3 animate-pulse text-slate-600">Carregant…</div>
+  <Loader />
 {:else}
   {#if err}<div class="rounded border border-red-300 bg-red-50 text-red-800 p-3 mb-3">{err}</div>{/if}
   {#if ok}<div class="rounded border border-green-300 bg-green-50 text-green-800 p-3 mb-3">{ok}</div>{/if}


### PR DESCRIPTION
## Summary
- add generic `Loader` component with compact spinner or skeleton states
- replace ad-hoc loading placeholders on challenge pages, admin config, and ranking with `<Loader />`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: Cannot find module 'vitest' and missing env exports)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f1ff9050832e91acf88baf9f2b44