### PR TITLE
feat: centralize UI alerts and banners

### DIFF
--- a/src/lib/components/Banner.svelte
+++ b/src/lib/components/Banner.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  export let type: 'success' | 'error' | 'info' | 'warn' = 'info';
+  export let message: string;
+
+  const styles = {
+    success: 'border-green-300 bg-green-50 text-green-800',
+    error: 'border-red-300 bg-red-50 text-red-800',
+    info: 'border-blue-300 bg-blue-50 text-blue-800',
+    warn: 'border-amber-300 bg-amber-50 text-amber-900'
+  } as const;
+
+  const icons = {
+    success: '✅',
+    error: '❌',
+    info: 'ℹ️',
+    warn: '⚠️'
+  } as const;
+</script>
+
+<div class={`flex items-center gap-2 rounded border p-3 text-sm ${styles[type]}`} {...$$restProps}>
+  <span>{icons[type]}</span>
+  <span>{message}</span>
+</div>

--- a/src/lib/ui/alerts.ts
+++ b/src/lib/ui/alerts.ts
@@ -1,0 +1,30 @@
+export function formatSupabaseError(e: unknown): string {
+  const message =
+    typeof e === 'string'
+      ? e
+      : typeof e === 'object' && e && 'message' in e
+      ? String((e as any).message)
+      : '';
+  const lower = message.toLowerCase();
+  if (
+    lower.includes('policy') ||
+    lower.includes('row level security') ||
+    lower.includes('row-level security') ||
+    lower.includes('permission')
+  ) {
+    return 'No tens permisos per fer aquesta acció.';
+  }
+  if (
+    lower.includes('violates') ||
+    lower.includes('invalid') ||
+    lower.includes('not-null') ||
+    lower.includes('duplicate key') ||
+    lower.includes('check constraint')
+  ) {
+    return 'Dades invàlides.';
+  }
+  return message || 'Error desconegut';
+}
+
+export const ok = (msg: string) => msg;
+export const err = (msg: string) => msg;

--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { supabase } from '$lib/supabaseClient';
-  import { isAdmin } from '$lib/isAdmin';
+    import { supabase } from '$lib/supabaseClient';
+    import { isAdmin } from '$lib/isAdmin';
+    import Banner from '$lib/components/Banner.svelte';
 
   let ready = false;
   let admin = false;
@@ -17,11 +18,9 @@
 
 {#if !ready}
   <div class="rounded border p-3">Comprovant permisos…</div>
-{:else if !admin}
-  <div class="rounded border border-red-300 bg-red-50 text-red-800 p-3">
-    No autoritzat. {email ? `Sessió: ${email}` : 'No hi ha sessió activa.'}
+  {:else if !admin}
+    <Banner type="error" message={email ? `No autoritzat. Sessió: ${email}` : 'No autoritzat. No hi ha sessió activa.'} />
     <div class="mt-2 text-sm"><a href="/login" class="underline">Inicia sessió</a></div>
-  </div>
-{:else}
-  <slot />
-{/if}
+  {:else}
+    <slot />
+  {/if}

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
-  import { goto } from '$app/navigation';
-  import { user } from '$lib/authStore';
+    import { onMount } from 'svelte';
+    import { goto } from '$app/navigation';
+    import { user } from '$lib/authStore';
+    import Banner from '$lib/components/Banner.svelte';
+    import { formatSupabaseError, err as errText } from '$lib/ui/alerts';
 
   let loading = true;
   let error: string | null = null;
@@ -29,14 +31,14 @@
 
       if (eAdm) throw eAdm;
       if (!adm) {
-        error = 'Només els administradors poden accedir a aquesta pàgina.';
+        error = errText('Només els administradors poden accedir a aquesta pàgina.');
         return;
       }
 
       isAdmin = true;
-    } catch (e: any) {
-      error = e?.message ?? 'Error en validar permisos';
-    } finally {
+      } catch (e) {
+        error = formatSupabaseError(e);
+      } finally {
       loading = false;
     }
   });
@@ -50,9 +52,9 @@
 
 {#if loading}
   <p class="text-slate-500">Carregant…</p>
-{:else if error}
-  <div class="rounded border border-red-300 bg-red-50 p-3 text-red-700">{error}</div>
-{:else if isAdmin}
+  {:else if error}
+    <Banner type="error" message={error} />
+  {:else if isAdmin}
   <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
     <!-- Targeta: crear repte -->
     <a href="/admin/reptes/nou" class="block rounded-2xl border p-4 hover:shadow-sm">

--- a/src/routes/admin/check/+page.svelte
+++ b/src/routes/admin/check/+page.svelte
@@ -2,26 +2,28 @@
   import { onMount } from 'svelte';
   import { supabase } from '$lib/supabaseClient';
   import { isAdmin } from '$lib/isAdmin';
+  import Banner from '$lib/components/Banner.svelte';
+  import { formatSupabaseError } from '$lib/ui/alerts';
 
   let email: string | null = null;
   let admin = false;
   let ready = false;
   let err: string | null = null;
 
-  onMount(async () => {
-    try {
-      const { data, error } = await supabase.auth.getSession();
-      if (error) throw error;
-      email = data.session?.user?.email ?? null;
+    onMount(async () => {
+      try {
+        const { data, error } = await supabase.auth.getSession();
+        if (error) throw error;
+        email = data.session?.user?.email ?? null;
 
-      // comprova admin amb la RLS de la taula public.admins
-      admin = await isAdmin();
-    } catch (e: any) {
-      err = e?.message ?? 'Error desconegut';
-    } finally {
-      ready = true;
-    }
-  });
+        // comprova admin amb la RLS de la taula public.admins
+        admin = await isAdmin();
+      } catch (e) {
+        err = formatSupabaseError(e);
+      } finally {
+        ready = true;
+      }
+    });
 </script>
 
 <svelte:head><title>Admin · Check</title></svelte:head>
@@ -31,9 +33,9 @@
 {#if !ready}
   <div class="rounded border p-3 text-slate-600">Comprovant…</div>
 {:else}
-  {#if err}
-    <div class="rounded border border-red-300 bg-red-50 text-red-800 p-3 mb-3">{err}</div>
-  {/if}
+    {#if err}
+      <Banner type="error" message={err} class="mb-3" />
+    {/if}
   <div class="rounded border p-3">
     <div><strong>Usuari:</strong> {email ?? '—'}</div>
     <div><strong>És admin?</strong> {admin ? 'sí' : 'no'}</div>

--- a/src/routes/admin/config/+page.svelte
+++ b/src/routes/admin/config/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
-  import { user, authReady as loadingAuth } from '$lib/authStore';
-  import { isAdmin as checkAdmin } from '$lib/isAdmin';
+    import { user, authReady as loadingAuth } from '$lib/authStore';
+    import { isAdmin as checkAdmin } from '$lib/isAdmin';
+    import Banner from '$lib/components/Banner.svelte';
+    import { formatSupabaseError, ok as okText, err as errText } from '$lib/ui/alerts';
 
   type Settings = {
     id?: string;
@@ -58,9 +60,9 @@
       if (admin) {
         await loadSettings();
       }
-    } catch (e: any) {
-      error = e?.message ?? 'No s’ha pogut carregar la configuració';
-    } finally {
+      } catch (e) {
+        error = formatSupabaseError(e);
+      } finally {
       loading = false;
     }
   }
@@ -115,12 +117,7 @@
           .from('app_settings')
           .update({ ...fields, updated_at: new Date().toISOString() })
           .eq('id', id);
-        if (e) {
-          if (e.code === '42501' || e.message?.toLowerCase().includes('permission')) {
-            throw new Error('Només administradors…');
-          }
-          throw e;
-        }
+        if (e) throw e;
       } else {
         const { data: inserted, error: e } = await supabase
           .from('app_settings')
@@ -136,18 +133,13 @@
           })
           .select('id')
           .single();
-        if (e) {
-          if (e.code === '42501' || e.message?.toLowerCase().includes('permission')) {
-            throw new Error('Només administradors…');
-          }
-          throw e;
-        }
+        if (e) throw e;
         form.id = inserted.id;
       }
       await loadSettings();
-      ok = 'Configuració desada';
-    } catch (err: any) {
-      error = err?.message ?? 'No s’ha pogut desar la configuració';
+      ok = okText('Configuració desada');
+    } catch (e) {
+      error = formatSupabaseError(e);
     } finally {
       saving = false;
     }
@@ -161,18 +153,18 @@
 {#if !$loadingAuth || loading}
   <p class="text-slate-500">Carregant…</p>
 {:else if !$user?.email}
-  <div class="rounded border border-red-300 bg-red-50 text-red-800 p-3">Has d’iniciar sessió</div>
+  <Banner type="error" message="Has d’iniciar sessió" />
 {:else if !admin}
-  <div class="rounded border border-red-300 bg-red-50 text-red-800 p-3">Només administradors…</div>
+  <Banner type="error" message="Només administradors…" />
 {:else}
   {#if warning}
-    <div class="mb-3 rounded border border-amber-300 bg-amber-50 text-amber-900 p-3">{warning}</div>
+    <Banner type="warn" message={warning} class="mb-3" />
   {/if}
   {#if error}
-    <div class="mb-3 rounded border border-red-300 bg-red-50 text-red-800 p-3">{error}</div>
+    <Banner type="error" message={error} class="mb-3" />
   {/if}
   {#if ok}
-    <div class="mb-3 rounded border border-green-300 bg-green-50 text-green-800 p-3">{ok}</div>
+    <Banner type="success" message={ok} class="mb-3" />
   {/if}
 
   {#if form}

--- a/src/routes/admin/penalitzacions/+page.svelte
+++ b/src/routes/admin/penalitzacions/+page.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
-  import { user } from '$lib/authStore';
-  import { isAdmin as checkAdmin } from '$lib/isAdmin';
+    import { onMount } from 'svelte';
+    import { user } from '$lib/authStore';
+    import { isAdmin as checkAdmin } from '$lib/isAdmin';
+    import Banner from '$lib/components/Banner.svelte';
+    import { formatSupabaseError, ok as okText, err as errText } from '$lib/ui/alerts';
 
   type Event = { id: string; nom: string };
   type Player = { id: string; nom: string };
@@ -50,9 +52,9 @@
       if (ePl) throw ePl;
       players = pl ?? [];
       if (players.length > 0) player_id = players[0].id;
-    } catch (e: any) {
-      error = e?.message ?? 'Error carregant dades';
-    } finally {
+      } catch (e) {
+        error = formatSupabaseError(e);
+      } finally {
       loading = false;
     }
   });
@@ -75,12 +77,12 @@
       });
       const js = await res.json();
       if (!res.ok) throw new Error(js.error || 'Error creant penalització');
-      okMsg = 'Penalització creada';
+        okMsg = okText('Penalització creada');
       tipus = 'incompareixenca';
       detalls = '';
-    } catch (e: any) {
-      error = e?.message ?? 'Error creant penalització';
-    } finally {
+      } catch (e) {
+        error = formatSupabaseError(e);
+      } finally {
       busy = false;
     }
   }
@@ -93,17 +95,17 @@
 <div class="max-w-2xl mx-auto">
   <h1 class="text-2xl font-semibold mb-4">Penalitzacions</h1>
 
-  {#if unauthorized}
-    <div class="rounded border border-red-300 bg-red-50 p-3 text-red-700">No autoritzat</div>
-  {:else if loading}
-    <p class="text-slate-500">Carregant…</p>
-  {:else}
-    {#if error}
-      <div class="mb-4 rounded border border-red-300 bg-red-50 p-3 text-red-700">{error}</div>
-    {/if}
-    {#if okMsg}
-      <div class="mb-4 rounded border border-green-300 bg-green-50 p-3 text-green-700">{okMsg}</div>
-    {/if}
+    {#if unauthorized}
+      <Banner type="error" message="No autoritzat" />
+    {:else if loading}
+      <p class="text-slate-500">Carregant…</p>
+    {:else}
+      {#if error}
+        <Banner type="error" message={error} class="mb-4" />
+      {/if}
+      {#if okMsg}
+        <Banner type="success" message={okMsg} class="mb-4" />
+      {/if}
 
     <div class="rounded-2xl border bg-white p-6 shadow-sm">
       <form class="space-y-4" on:submit|preventDefault={save}>

--- a/src/routes/admin/reptes/+page.svelte
+++ b/src/routes/admin/reptes/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
-  import { user, isAdmin } from '$lib/authStore';
+    import { onMount } from 'svelte';
+    import { user, isAdmin } from '$lib/authStore';
+    import Banner from '$lib/components/Banner.svelte';
+    import { formatSupabaseError, ok as okText, err as errText } from '$lib/ui/alerts';
 
   type ChallengeRow = {
     id: string;
@@ -56,15 +58,15 @@
       error = null;
       okMsg = null;
 
-      if (!$user?.email) {
-        error = 'Has d\u2019iniciar sessi\u00f3.';
-        return;
-      }
-      // aquesta pàgina està pensada per a administradors
-      if (!$isAdmin) {
-        error = 'Només administradors poden veure aquesta pàgina.';
-        return;
-      }
+        if (!$user?.email) {
+          error = errText('Has d’iniciar sessió.');
+          return;
+        }
+        // aquesta pàgina està pensada per a administradors
+        if (!$isAdmin) {
+          error = errText('Només administradors poden veure aquesta pàgina.');
+          return;
+        }
 
       const { supabase } = await import('$lib/supabaseClient');
 
@@ -102,9 +104,9 @@
       }
       dateChoice = new Map(dateChoice);
       reprogLocal = new Map(reprogLocal);
-    } catch (e: any) {
-      error = e?.message ?? 'No s\u2019ha pogut carregar la llista de reptes';
-    } finally {
+      } catch (e) {
+        error = formatSupabaseError(e);
+      } finally {
       loading = false;
     }
   }
@@ -170,7 +172,7 @@
   async function acceptWithDate(r: ChallengeRow) {
     const iso = dateChoice.get(r.id);
     if (!iso) {
-      error = 'Cal seleccionar una data.';
+      error = errText('Cal seleccionar una data.');
       return;
     }
     try {
@@ -184,10 +186,10 @@
       });
       const out = await res.json();
       if (!out.ok) throw new Error(out.error || 'No s\u2019ha pogut programar');
-      okMsg = 'Repte programat correctament.';
+      okMsg = okText('Repte programat correctament.');
       await load();
-    } catch (e: any) {
-      error = e?.message ?? 'No s\u2019ha pogut programar el repte';
+    } catch (e) {
+      error = formatSupabaseError(e);
     } finally {
       busy = null;
     }
@@ -205,10 +207,10 @@
       });
       const out = await res.json();
       if (!out.ok) throw new Error(out.error || 'No s\u2019ha pogut acceptar');
-      okMsg = 'Repte acceptat.';
+      okMsg = okText('Repte acceptat.');
       await load();
-    } catch (e: any) {
-      error = e?.message ?? 'No s\u2019ha pogut acceptar el repte';
+    } catch (e) {
+      error = formatSupabaseError(e);
     } finally {
       busy = null;
     }
@@ -218,11 +220,11 @@
     const local = reprogLocal.get(r.id) ?? '';
     const iso = new Date(local).toISOString();
     if (!local || isNaN(new Date(local).getTime())) {
-      error = 'Cal indicar una data v\u00e0lida.';
+      error = errText('Cal indicar una data vàlida.');
       return;
     }
     if (new Date(iso) < new Date()) {
-      error = 'La nova data ha de ser futura.';
+      error = errText('La nova data ha de ser futura.');
       return;
     }
     try {
@@ -239,10 +241,10 @@
         })
         .eq('id', r.id);
       if (e) throw e;
-      okMsg = 'Data reprogramada correctament.';
+      okMsg = okText('Data reprogramada correctament.');
       await load();
-    } catch (e: any) {
-      error = e?.message ?? 'No s\u2019ha pogut reprogramar';
+    } catch (e) {
+      error = formatSupabaseError(e);
     } finally {
       busy = null;
     }
@@ -275,11 +277,11 @@
       const payload: any = { estat: newState, ...(also ?? {}) };
       const { error: e } = await supabase.from('challenges').update(payload).eq('id', id);
       if (e) throw e;
-      okMsg = `Repte actualitzat a \"${newState}\".`;
+        okMsg = okText(`Repte actualitzat a "${newState}".`);
       await load();
-    } catch (e: any) {
-      error = e?.message ?? 'No s\u2019ha pogut actualitzar el repte';
-    } finally {
+      } catch (e) {
+        error = formatSupabaseError(e);
+      } finally {
       busy = null;
     }
   }
@@ -292,12 +294,12 @@
 {#if loading}
   <div class="animate-pulse rounded border p-4 text-slate-500">Carregant…</div>
 {:else}
-  {#if error}
-    <div class="rounded border border-red-300 bg-red-50 text-red-800 p-3 mb-3">{error}</div>
-  {/if}
-  {#if okMsg}
-    <div class="rounded border border-green-300 bg-green-50 text-green-800 p-3 mb-3">{okMsg}</div>
-  {/if}
+    {#if error}
+      <Banner type="error" message={error} class="mb-3" />
+    {/if}
+    {#if okMsg}
+      <Banner type="success" message={okMsg} class="mb-3" />
+    {/if}
 
   <div class="overflow-auto rounded border">
     <table class="min-w-full text-sm">


### PR DESCRIPTION
## Summary
- add shared `formatSupabaseError`, `ok`, and `err` helpers
- introduce reusable `<Banner>` component for success/error/info/warn messages
- refactor admin and reptes pages to use Banner and formatted Supabase errors

## Testing
- `pnpm check` *(fails: Cannot find module 'vitest' and missing env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f1c9a02c832eb82f00d90efb57ce