### PR TITLE
Invalidate admin cache on auth change

### DIFF
--- a/src/lib/authStore.ts
+++ b/src/lib/authStore.ts
@@ -19,10 +19,11 @@ export async function initAuth() {
     user.set(sessUser ? { email: sessUser.email ?? null } : null);
 
     // 2) escolta canvis d'autenticació
-    supabase.auth.onAuthStateChange(async (_event, session) => {
+    supabase.auth.onAuthStateChange((_event, session) => {
       const u = session?.user ?? null;
       user.set(u ? { email: u.email ?? null } : null);
-      await refreshAdmin();
+      invalidateAdminCache();
+      void refreshAdmin();
     });
 
     // 3) calcula admin un cop carregada la sessió


### PR DESCRIPTION
## Summary
- invalidate admin cache and refresh admin on auth state change

## Testing
- `pnpm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c2966065ac832eb732a16b34ac38c3