### PR TITLE
refactor: use roles API for admin checks

### DIFF
--- a/src/lib/components/Nav.svelte
+++ b/src/lib/components/Nav.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { page } from '$app/stores';
     import { user, logout } from '$lib/authStore';
-    import { adminStore as isAdmin } from '$lib/roles';
+    import { adminStore } from '$lib/roles';
 
   // enllaços sempre visibles
   const baseLinks = [
@@ -63,7 +63,7 @@
           </li>
         {/if}
 
-        {#if $user && $isAdmin}
+        {#if $user && $adminStore}
           <li>
 
             <a href="/admin" class="px-2 py-1 rounded hover:bg-slate-100 hover:underline">
@@ -149,7 +149,7 @@
           </li>
         {/if}
 
-        {#if $user && $isAdmin}
+        {#if $user && $adminStore}
           <li>
             <a
               href="/admin"

--- a/src/lib/isAdmin.ts
+++ b/src/lib/isAdmin.ts
@@ -1,0 +1,4 @@
+/**
+ * @deprecated Utilitza les funcions de '$lib/roles'.
+ */
+export { adminStore, refreshAdmin, checkIsAdmin } from './roles';

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,7 +2,7 @@
   import "../app.css";
   import { onMount } from "svelte";
     import { user, authReady, initAuth, logout } from "$lib/authStore";
-    import { adminStore as isAdmin } from '$lib/roles';
+    import { adminStore } from '$lib/roles';
 
   onMount(() => {
     // Inicialitza sessió + rol admin en muntar el layout
@@ -27,7 +27,7 @@
       <a href="/reptes/nou" class={isActive("/reptes/nou", $page.url.pathname)}>Crear repte</a>
     {/if}
 
-    {#if $authReady && $isAdmin}
+    {#if $authReady && $adminStore}
       <a href="/admin" class={isActive("/admin", $page.url.pathname)}>Admin</a>
     {/if}
 
@@ -56,6 +56,6 @@
 <!-- DEBUG opcional: treu-ho quan vulguis -->
 {#if $authReady}
   <div class="fixed bottom-2 right-2 text-xs bg-slate-800 text-white px-2 py-1 rounded">
-    {$user?.email ?? "anònim"} | admin: {$isAdmin ? "sí" : "no"}
+    {$user?.email ?? "anònim"} | admin: {$adminStore ? "sí" : "no"}
   </div>
 {/if}

--- a/src/routes/admin/reptes/[id]/programar/+page.svelte
+++ b/src/routes/admin/reptes/[id]/programar/+page.svelte
@@ -2,7 +2,7 @@
       import { onMount } from 'svelte';
       import { page } from '$app/stores';
       import { user } from '$lib/authStore';
-      import { adminStore as isAdmin } from '$lib/roles';
+      import { checkIsAdmin } from '$lib/roles';
     import Banner from '$lib/components/Banner.svelte';
     import { formatSupabaseError, ok as okText, err as errText } from '$lib/ui/alerts';
 
@@ -41,7 +41,8 @@
           error = errText('Has d’iniciar sessió.');
           return;
         }
-        if (!$isAdmin) {
+        const isAdmin = await checkIsAdmin();
+        if (!isAdmin) {
           error = errText('Només administradors poden programar reptes.');
           return;
         }

--- a/src/routes/admin/reptes/[id]/resultat/+page.svelte
+++ b/src/routes/admin/reptes/[id]/resultat/+page.svelte
@@ -3,7 +3,7 @@
       import { onMount } from 'svelte';
       import { page } from '$app/stores';
       import { user } from '$lib/authStore';
-      import { adminStore as isAdmin } from '$lib/roles';
+      import { checkIsAdmin } from '$lib/roles';
       import type { AppSettings } from '$lib/settings';
       import Banner from '$lib/components/Banner.svelte';
       import Loader from '$lib/components/Loader.svelte';
@@ -52,7 +52,8 @@
       loading = true; error = null; okMsg = null; rpcMsg = null;
 
         if (!$user?.email) { error = errText('Has d’iniciar sessió.'); return; }
-        if (!$isAdmin) { error = errText('Només administradors poden registrar resultats.'); return; }
+        const isAdmin = await checkIsAdmin();
+        if (!isAdmin) { error = errText('Només administradors poden registrar resultats.'); return; }
 
       const { supabase } = await import('$lib/supabaseClient');
 

--- a/src/routes/reptes/[id]/resultat/+page.svelte
+++ b/src/routes/reptes/[id]/resultat/+page.svelte
@@ -2,7 +2,7 @@
       import { onMount } from 'svelte';
       import { page } from '$app/stores';
       import { user } from '$lib/authStore';
-      import { adminStore as isAdmin } from '$lib/roles';
+      import { checkIsAdmin } from '$lib/roles';
     import Banner from '$lib/components/Banner.svelte';
     import { formatSupabaseError, ok as okText, err as errText } from '$lib/ui/alerts';
 
@@ -56,7 +56,8 @@
       loading = true; error = null;
 
         if (!$user?.email) { error = errText('Has d’iniciar sessió.'); return; }
-        if (!$isAdmin) { error = errText('Només admins poden posar resultats.'); return; }
+        const isAdmin = await checkIsAdmin();
+        if (!isAdmin) { error = errText('Només admins poden posar resultats.'); return; }
 
       const { supabase } = await import('$lib/supabaseClient');
 


### PR DESCRIPTION
## Summary
- use `adminStore` to toggle Admin UI links
- gate admin routes with `checkIsAdmin`
- provide deprecated `isAdmin` shim forwarding to roles API

## Testing
- `pnpm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c2975f6e90832eb3ac99f2b06ee2c6