### PR TITLE
feat: add championship reset endpoint and UI

### DIFF
--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -6,7 +6,6 @@
   import Banner from '$lib/components/Banner.svelte';
   import Loader from '$lib/components/Loader.svelte';
   import { formatSupabaseError, err as errText } from '$lib/ui/alerts';
-  import Loader from '$lib/components/Loader.svelte';
 
   let loading = true;
   let error: string | null = null;
@@ -24,6 +23,11 @@
   let inactBusy = false;
   let inactOk: string | null = null;
   let inactErr: string | null = null;
+
+  let resetBusy = false;
+  let resetOk: string | null = null;
+  let resetErr: string | null = null;
+  let clearWaiting = false;
 
   type Change = {
     creat_el: string;
@@ -127,6 +131,33 @@
       inactErr = formatSupabaseError(e);
     } finally {
       inactBusy = false;
+    }
+  }
+
+  async function resetChampionship() {
+    if (!confirm('Segur que vols fer un reset del campionat?')) return;
+    try {
+      resetBusy = true;
+      resetOk = null;
+      resetErr = null;
+      const { supabase } = await import('$lib/supabaseClient');
+      const { data } = await supabase.auth.getSession();
+      const token = data?.session?.access_token;
+      const res = await fetch('/admin/reset', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: 'Bearer ' + token
+        },
+        body: JSON.stringify({ clearWaiting })
+      });
+      const js = await res.json();
+      if (!res.ok || !js.ok) throw new Error(js.error || 'Error resetejant campionat');
+      resetOk = `Campionat reiniciat (${js.restored})`;
+    } catch (e) {
+      resetErr = formatSupabaseError(e);
+    } finally {
+      resetBusy = false;
     }
   }
 
@@ -294,6 +325,34 @@
           disabled={inactBusy}
         >
           {#if inactBusy}Executant…{:else}Executa inactivitat (42 dies){/if}
+        </button>
+      </div>
+    </div>
+
+    <!-- Targeta: reset campionat -->
+    <div class="rounded-2xl border p-4">
+      <h2 class="font-semibold">🧹 Neteja de proves / Reset rànquing</h2>
+      {#if resetOk}
+        <Banner type="success" message={resetOk} class="mb-2" />
+      {/if}
+      {#if resetErr}
+        <Banner type="error" message={resetErr} class="mb-2" />
+      {/if}
+      <div class="mt-2 space-y-2 text-sm">
+        <label class="flex items-center gap-2">
+          <input
+            type="checkbox"
+            bind:checked={clearWaiting}
+            class="rounded border"
+          />
+          Buidar també la llista d’espera
+        </label>
+        <button
+          class="rounded-xl bg-slate-900 px-4 py-2 text-white disabled:opacity-50"
+          on:click={resetChampionship}
+          disabled={resetBusy}
+        >
+          {#if resetBusy}Resetant…{:else}Reset campionat{/if}
         </button>
       </div>
     </div>

--- a/src/routes/admin/reset/+server.ts
+++ b/src/routes/admin/reset/+server.ts
@@ -1,0 +1,36 @@
+import type { RequestHandler } from './$types';
+import { json } from '@sveltejs/kit';
+import { checkIsAdmin } from '$lib/roles';
+import { serverSupabase } from '$lib/server/supabaseAdmin';
+
+export const POST: RequestHandler = async ({ request }) => {
+  try {
+    let body: { clearWaiting?: boolean } | null = null;
+    try {
+      body = await request.json();
+    } catch {
+      return json({ ok: false, error: 'Cos JSON requerit' }, { status: 400 });
+    }
+
+    const clearWaiting = !!body?.clearWaiting;
+
+    const isAdmin = await checkIsAdmin();
+    if (!isAdmin) {
+      return json({ ok: false, error: 'Només admins' }, { status: 403 });
+    }
+
+    const supabase = serverSupabase(request);
+    const { data, error } = await supabase.rpc('reset_event_to_initial', {
+      p_event: null,
+      p_clear_waiting: clearWaiting
+    });
+    if (error) {
+      return json({ ok: false, error: 'Error resetejant campionat' }, { status: 400 });
+    }
+
+    return json({ ok: true, restored: data ?? 0 });
+  } catch (e: any) {
+    return json({ ok: false, error: e?.message ?? 'Error intern' }, { status: 500 });
+  }
+};
+


### PR DESCRIPTION
## Summary
- allow admins to reset championship state via new endpoint
- add admin UI card with checkbox to optionally clear waiting list

## Testing
- `pnpm check`


------
https://chatgpt.com/codex/tasks/task_e_68c3ca8cdbc0832e8016370781c1ffa6