### PR TITLE
refactor: migrate isAdmin to roles

### DIFF
--- a/src/lib/components/Nav.svelte
+++ b/src/lib/components/Nav.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { page } from '$app/stores';
-  import { user, isAdmin, logout } from '$lib/authStore';
+  import { user, logout } from '$lib/authStore';
+  import { adminStore } from '$lib/roles';
 
   // enllaços sempre visibles
   const baseLinks = [
@@ -62,7 +63,7 @@
           </li>
         {/if}
 
-        {#if $user && $isAdmin}
+        {#if $user && $adminStore}
           <li>
             <a
               href="/admin"
@@ -146,7 +147,7 @@
           </li>
         {/if}
 
-        {#if $user && $isAdmin}
+        {#if $user && $adminStore}
           <li>
             <a
               href="/admin"

--- a/src/lib/isAdmin.ts
+++ b/src/lib/isAdmin.ts
@@ -1,4 +1,0 @@
-/**
- * @deprecated Utilitza les funcions de '$lib/roles'.
- */
-export { adminStore, refreshAdmin, checkIsAdmin } from './roles';

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -39,7 +39,7 @@ export async function getSettings(): Promise<AppSettings> {
   } catch {
     cache = DEFAULT_SETTINGS;
   }
-  return cache;
+    return cache as AppSettings;
 }
 
 export function invalidate() {

--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -1,24 +1,23 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
-  import { isAdmin } from '$lib/authStore';
+    import { onMount } from 'svelte';
+    import { adminStore, checkIsAdmin } from '$lib/roles';
 
-  let admin = false;
-  let checked = false;
+    let checked = false;
 
-  onMount(() => {
-    const unsub = isAdmin.subscribe((v) => {
-      admin = v;
+    onMount(async () => {
+      const ok = await checkIsAdmin();
       checked = true;
+      if (!ok) {
+        // adminStore remains false; unauthorized message will show
+      }
     });
-    return unsub;
-  });
-</script>
+  </script>
 
-{#if admin}
-  <slot />
-{:else if checked}
-  <div class="m-4 rounded border border-red-300 bg-red-50 p-4 text-red-800">
-    No autoritzat — <a href="/" class="underline">Inici</a>
-  </div>
-{/if}
+  {#if $adminStore}
+    <slot />
+  {:else if checked}
+    <div class="m-4 rounded border border-red-300 bg-red-50 p-4 text-red-800">
+      No autoritzat — <a href="/" class="underline">Inici</a>
+    </div>
+  {/if}
 

--- a/src/routes/admin/config/+page.svelte
+++ b/src/routes/admin/config/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-    import { user, authReady as loadingAuth } from '$lib/authStore';
+    import { onMount } from 'svelte';
+    import { user } from '$lib/authStore';
     import { checkIsAdmin } from '$lib/roles';
     import Banner from '$lib/components/Banner.svelte';
     import Loader from '$lib/components/Loader.svelte';
@@ -26,7 +27,6 @@
   let ok: string | null = null;
   let loading = true;
   let admin = false;
-  let started = false;
 
   async function loadSettings() {
     const { supabase } = await import('$lib/supabaseClient');
@@ -69,10 +69,7 @@
     }
   }
 
-  $: if ($loadingAuth && $user?.email && !started) {
-    started = true;
-    init();
-  }
+  onMount(init);
 
   function validate(): string | null {
     if (!form) return null;
@@ -152,7 +149,7 @@
 
 <h1 class="text-2xl font-semibold mb-4">Administració — Configuració</h1>
 
-{#if !$loadingAuth || loading}
+{#if loading}
   <Loader />
 {:else if !$user?.email}
   <Banner type="error" message="Has d’iniciar sessió" />

--- a/src/routes/admin/reptes/[id]/resultat/+page.svelte
+++ b/src/routes/admin/reptes/[id]/resultat/+page.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { page } from '$app/stores';
-  import { user, isAdmin } from '$lib/authStore';
+  import { user } from '$lib/authStore';
+  import { checkIsAdmin } from '$lib/roles';
   import { getSettings, type AppSettings } from '$lib/settings';
 
   type Challenge = {
@@ -24,7 +25,7 @@
   let reptadorNom = '—';
   let reptatNom = '—';
 
-  let settings: AppSettings = await getSettings();
+  let settings: AppSettings;
 
   // Formulari
   let carR: number | '' = 0;
@@ -46,7 +47,10 @@
       loading = true; error = null; okMsg = null; rpcMsg = null;
 
       if (!$user?.email) { error = 'Has d’iniciar sessió.'; return; }
-      if (!$isAdmin) { error = 'Només administradors poden registrar resultats.'; return; }
+      const adm = await checkIsAdmin();
+      if (!adm) { error = 'Només administradors poden registrar resultats.'; return; }
+
+      settings = await getSettings();
 
       const { supabase } = await import('$lib/supabaseClient');
 


### PR DESCRIPTION
## Summary
- replace deprecated `isAdmin` imports with `adminStore` from `roles`
- guard admin pages using `checkIsAdmin` and drop `loadingAuth`
- fix settings return type and remove leftover `isAdmin.ts`

## Testing
- `pnpm check`

------
https://chatgpt.com/codex/tasks/task_e_68c3d368c8b0832eabecdf40890df3af