### PR TITLE
feat(auth): re-export roles API for transition

### DIFF
--- a/src/lib/authStore.ts
+++ b/src/lib/authStore.ts
@@ -40,3 +40,6 @@ export async function logout() {
   invalidateAdminCache();
   adminStore.set(false);
 }
+
+// Compatibilitat temporal: reexporta API de roles
+export { adminStore, checkIsAdmin as isAdmin, refreshAdmin } from '$lib/roles';


### PR DESCRIPTION
## Summary
- re-export admin role helpers from authStore for compatibility

## Testing
- `pnpm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c3d522dcfc832eb1cf35c03453f5cd