### PR TITLE
feat: enforce server-side admin guard

### DIFF
--- a/src/lib/server/adminGuard.ts
+++ b/src/lib/server/adminGuard.ts
@@ -1,0 +1,48 @@
+import { createClient } from '@supabase/supabase-js';
+import { error, type RequestEvent } from '@sveltejs/kit';
+
+function getToken(event: RequestEvent): string | null {
+  return (
+    event.cookies.get('sb-access-token') ??
+    event.request.headers.get('authorization')?.replace(/^Bearer\s+/i, '') ??
+    null
+  );
+}
+
+export async function getServerUser(event: RequestEvent): Promise<{ email: string } | null> {
+  const token = getToken(event);
+  if (!token) return null;
+
+  const supabase = createClient(
+    import.meta.env.PUBLIC_SUPABASE_URL,
+    import.meta.env.PUBLIC_SUPABASE_ANON_KEY,
+    { global: { headers: { Authorization: `Bearer ${token}` } } }
+  );
+
+  const { data, error: userErr } = await supabase.auth.getUser();
+  const email = data.user?.email ?? null;
+  if (userErr || !email) return null;
+  return { email };
+}
+
+export async function requireAdmin(event: RequestEvent): Promise<{ email: string }> {
+  const user = await getServerUser(event);
+  if (!user) {
+    throw error(401, 'Unauthorized');
+  }
+
+  const token = getToken(event) ?? '';
+  const supabase = createClient(
+    import.meta.env.PUBLIC_SUPABASE_URL,
+    import.meta.env.PUBLIC_SUPABASE_ANON_KEY,
+    { global: { headers: { Authorization: `Bearer ${token}` } } }
+  );
+
+  const { data: isAdmin, error: adminErr } = await supabase.rpc('is_admin', { p_email: user.email });
+  if (adminErr || !isAdmin) {
+    throw error(403, 'Només admins');
+  }
+
+  return user;
+}
+

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -162,15 +162,10 @@
       resetBusy = true;
       resetOk = null;
       resetErr = null;
-      const { supabase } = await import('$lib/supabaseClient');
-      const { data } = await supabase.auth.getSession();
-      const token = data?.session?.access_token;
       const res = await fetch('/admin/reset', {
         method: 'POST',
-        headers: {
-          'content-type': 'application/json',
-          authorization: 'Bearer ' + token
-        },
+        headers: { 'content-type': 'application/json' },
+        credentials: 'include',
         body: JSON.stringify({ clearWaiting })
       });
       const js = await res.json();

--- a/src/routes/admin/reset/+server.ts
+++ b/src/routes/admin/reset/+server.ts
@@ -1,36 +1,28 @@
-import type { RequestHandler } from './$types';
 import { json } from '@sveltejs/kit';
-import { checkIsAdmin } from '$lib/roles';
-import { serverSupabase } from '$lib/server/supabaseAdmin';
+import { requireAdmin } from '$lib/server/adminGuard';
+import { createClient } from '@supabase/supabase-js';
 
-export const POST: RequestHandler = async ({ request }) => {
-  try {
-    let body: { clearWaiting?: boolean } | null = null;
-    try {
-      body = await request.json();
-    } catch {
-      return json({ ok: false, error: 'Cos JSON requerit' }, { status: 400 });
-    }
+export async function POST(event) {
+  await requireAdmin(event);
 
-    const clearWaiting = !!body?.clearWaiting;
+  const token =
+    event.cookies.get('sb-access-token') ??
+    event.request.headers.get('authorization')?.replace(/^Bearer\s+/i, '') ??
+    '';
+  const supabase = createClient(
+    import.meta.env.PUBLIC_SUPABASE_URL,
+    import.meta.env.PUBLIC_SUPABASE_ANON_KEY,
+    { global: { headers: { Authorization: `Bearer ${token}` } } }
+  );
 
-    const isAdmin = await checkIsAdmin();
-    if (!isAdmin) {
-      return json({ ok: false, error: 'Només admins' }, { status: 403 });
-    }
-
-    const supabase = serverSupabase(request);
-    const { data, error } = await supabase.rpc('reset_event_to_initial', {
-      p_event: null,
-      p_clear_waiting: clearWaiting
-    });
-    if (error) {
-      return json({ ok: false, error: 'Error resetejant campionat' }, { status: 400 });
-    }
-
-    return json({ ok: true, restored: data ?? 0 });
-  } catch (e: any) {
-    return json({ ok: false, error: e?.message ?? 'Error intern' }, { status: 500 });
+  const { clearWaiting = false } = await event.request.json().catch(() => ({}));
+  const { data, error } = await supabase.rpc('reset_event_to_initial', {
+    p_event: null,
+    p_clear_waiting: !!clearWaiting
+  });
+  if (error) {
+    return new Response(JSON.stringify({ ok: false, error: error.message }), { status: 500 });
   }
-};
+  return json({ ok: true, ...(data ?? {}) });
+}
 


### PR DESCRIPTION
## Summary
- add server admin guard that verifies Supabase session and checks `public.is_admin`
- protect admin endpoints with server guard and forward user token for RLS
- send cookies on reset request from admin UI

## Testing
- `pnpm check`


------
https://chatgpt.com/codex/tasks/task_e_68c3d868487c832eb446c09becd86331