### PR TITLE
feat: add whoami diagnostic endpoint

### DIFF
--- a/src/routes/admin/whoami/+server.ts
+++ b/src/routes/admin/whoami/+server.ts
@@ -1,0 +1,23 @@
+import { json } from '@sveltejs/kit';
+import { createClient } from '@supabase/supabase-js';
+
+export async function GET(event) {
+  const token =
+    event.cookies.get('sb-access-token') ??
+    event.request.headers.get('authorization')?.replace(/^Bearer\s+/i, '') ??
+    '';
+  const supabase = createClient(
+    import.meta.env.PUBLIC_SUPABASE_URL,
+    import.meta.env.PUBLIC_SUPABASE_ANON_KEY,
+    { global: { headers: token ? { Authorization: `Bearer ${token}` } : {} } }
+  );
+
+  const { data: userData, error } = await supabase.auth.getUser();
+  return json({
+    hasCookieToken: Boolean(event.cookies.get('sb-access-token')),
+    hasAuthHeader: Boolean(event.request.headers.get('authorization')),
+    email: userData?.user?.email ?? null,
+    authError: error?.message ?? null
+  });
+}
+


### PR DESCRIPTION
## Summary
- add admin whoami endpoint to inspect authentication tokens

## Testing
- `pnpm check`


------
https://chatgpt.com/codex/tasks/task_e_68c3db6e75e0832eb34bbc37e1d0d1f3