### PR TITLE
feat: add universal admin guard and fix reset route

### DIFF
--- a/src/lib/server/adminGuard.ts
+++ b/src/lib/server/adminGuard.ts
@@ -1,48 +1,33 @@
 import { createClient } from '@supabase/supabase-js';
-import { error, type RequestEvent } from '@sveltejs/kit';
 
-function getToken(event: RequestEvent): string | null {
-  return (
+export function serverSupabase(event: Parameters<import('@sveltejs/kit').RequestHandler>[0]) {
+  const token =
     event.cookies.get('sb-access-token') ??
     event.request.headers.get('authorization')?.replace(/^Bearer\s+/i, '') ??
-    null
+    '';
+  return createClient(
+    import.meta.env.PUBLIC_SUPABASE_URL,
+    import.meta.env.PUBLIC_SUPABASE_ANON_KEY,
+    { global: { headers: token ? { Authorization: `Bearer ${token}` } : {} } }
   );
 }
 
-export async function getServerUser(event: RequestEvent): Promise<{ email: string } | null> {
-  const token = getToken(event);
-  if (!token) return null;
-
-  const supabase = createClient(
-    import.meta.env.PUBLIC_SUPABASE_URL,
-    import.meta.env.PUBLIC_SUPABASE_ANON_KEY,
-    { global: { headers: { Authorization: `Bearer ${token}` } } }
-  );
-
-  const { data, error: userErr } = await supabase.auth.getUser();
-  const email = data.user?.email ?? null;
-  if (userErr || !email) return null;
-  return { email };
-}
-
-export async function requireAdmin(event: RequestEvent): Promise<{ email: string }> {
-  const user = await getServerUser(event);
-  if (!user) {
-    throw error(401, 'Unauthorized');
+export async function requireAdmin(
+  event: Parameters<import('@sveltejs/kit').RequestHandler>[0]
+) {
+  const supabase = serverSupabase(event);
+  const { data: u } = await supabase.auth.getUser();
+  const email = u?.user?.email ?? null;
+  if (!email) {
+    return new Response(JSON.stringify({ error: 'No autenticat' }), { status: 401 });
   }
-
-  const token = getToken(event) ?? '';
-  const supabase = createClient(
-    import.meta.env.PUBLIC_SUPABASE_URL,
-    import.meta.env.PUBLIC_SUPABASE_ANON_KEY,
-    { global: { headers: { Authorization: `Bearer ${token}` } } }
-  );
-
-  const { data: isAdmin, error: adminErr } = await supabase.rpc('is_admin', { p_email: user.email });
-  if (adminErr || !isAdmin) {
-    throw error(403, 'Només admins');
+  const { data, error } = await supabase.rpc('is_admin', { p_email: email });
+  if (error) {
+    return new Response(JSON.stringify({ error: error.message }), { status: 500 });
   }
-
-  return user;
+  if (!data) {
+    return new Response(JSON.stringify({ error: 'No autoritzat' }), { status: 403 });
+  }
+  return null; // ok
 }
 

--- a/src/routes/admin/reset/+server.ts
+++ b/src/routes/admin/reset/+server.ts
@@ -1,20 +1,11 @@
 import { json } from '@sveltejs/kit';
-import { requireAdmin } from '$lib/server/adminGuard';
-import { createClient } from '@supabase/supabase-js';
+import { serverSupabase, requireAdmin } from '$lib/server/adminGuard';
 
 export async function POST(event) {
-  await requireAdmin(event);
+  const guard = await requireAdmin(event);
+  if (guard) return guard; // 401/403/500
 
-  const token =
-    event.cookies.get('sb-access-token') ??
-    event.request.headers.get('authorization')?.replace(/^Bearer\s+/i, '') ??
-    '';
-  const supabase = createClient(
-    import.meta.env.PUBLIC_SUPABASE_URL,
-    import.meta.env.PUBLIC_SUPABASE_ANON_KEY,
-    { global: { headers: { Authorization: `Bearer ${token}` } } }
-  );
-
+  const supabase = serverSupabase(event);
   const { clearWaiting = false } = await event.request.json().catch(() => ({}));
   const { data, error } = await supabase.rpc('reset_event_to_initial', {
     p_event: null,


### PR DESCRIPTION
## Summary
- add helper to create supabase client and require admin via RPC
- secure admin reset endpoint using the new guard

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c3db7fcd8c832e84ec780e75d8fa5d