### PR TITLE
Fix penalization endpoint admin guard

### DIFF
--- a/src/routes/reptes/penalitzacions/+server.ts
+++ b/src/routes/reptes/penalitzacions/+server.ts
@@ -2,7 +2,8 @@ import { json } from '@sveltejs/kit';
 import { serverSupabase, requireAdmin } from '$lib/server/adminGuard';
 
 export async function POST(event) {
-  await requireAdmin(event);
+  const guard = await requireAdmin(event);
+  if (guard) return guard; // 401/403/500
 
   const supabase = serverSupabase(event);
   let payload: { challenge_id?: string; tipus?: 'incompareixenca' | 'desacord_dates' };


### PR DESCRIPTION
## Summary
- fix penalization endpoint to return guard responses for unauthorized users

## Testing
- `pnpm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c3eadb7540832e8fb8acead4bda07d