### PR TITLE
fix: validate admin challenge penalties

### DIFF
--- a/src/routes/reptes/penalitzacions/+server.ts
+++ b/src/routes/reptes/penalitzacions/+server.ts
@@ -1,27 +1,45 @@
 import { json } from '@sveltejs/kit';
 import { serverSupabase, requireAdmin } from '$lib/server/adminGuard';
 
+const PENALTY_TYPES = ['incompareixenca', 'desacord_dates'] as const;
+
 export async function POST(event) {
   const guard = await requireAdmin(event);
   if (guard) return guard; // 401/403/500
 
   const supabase = serverSupabase(event);
-  let payload: { challenge_id?: string; tipus?: 'incompareixenca' | 'desacord_dates' };
+  let payload: { challenge_id?: string; tipus?: string };
   try {
     payload = await event.request.json();
   } catch {
-    return new Response(JSON.stringify({ error: 'JSON invàlid' }), { status: 400 });
+    return json({ error: 'JSON invàlid' }, { status: 400 });
   }
   const { challenge_id, tipus } = payload;
   if (!challenge_id || !tipus) {
-    return new Response(JSON.stringify({ error: 'Falten camps: challenge_id, tipus' }), { status: 400 });
+    return json({ error: 'Falten camps: challenge_id, tipus' }, { status: 400 });
   }
+  if (!PENALTY_TYPES.includes(tipus as any)) {
+    return json({ error: 'Tipus no suportat' }, { status: 400 });
+  }
+
+  const { data: chal, error: chalErr } = await supabase
+    .from('challenges')
+    .select('id')
+    .eq('id', challenge_id)
+    .maybeSingle();
+  if (chalErr) {
+    return json({ error: "No s'ha pogut comprovar el repte" }, { status: 500 });
+  }
+  if (!chal) {
+    return json({ error: 'Repte no trobat' }, { status: 404 });
+  }
+
   const { data, error } = await supabase.rpc('apply_challenge_penalty', {
     p_challenge: challenge_id,
     p_tipus: tipus
   });
   if (error) {
-    return new Response(JSON.stringify({ ok: false, error: error.message }), { status: 500 });
+    return json({ error: 'Error aplicant penalització' }, { status: 500 });
   }
   return json({ ok: true, ...(data ?? {}) });
 }


### PR DESCRIPTION
## Summary
- add validation and clearer errors to challenge penalty API

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c3f195c3f8832e9841e8992e19a261