### PR TITLE
Persist Supabase session in cookies

### DIFF
--- a/src/routes/admin/penalitzacions/+server.ts
+++ b/src/routes/admin/penalitzacions/+server.ts
@@ -1,7 +1,6 @@
 import type { RequestHandler } from './$types';
 import { json } from '@sveltejs/kit';
-import { requireAdmin } from '$lib/server/adminGuard';
-import { createClient } from '@supabase/supabase-js';
+import { requireAdmin, serverSupabase } from '$lib/server/adminGuard';
 
 function isRlsError(e: any): boolean {
   const msg = String(e?.message || '').toLowerCase();
@@ -28,15 +27,7 @@ export const POST: RequestHandler = async (event) => {
 
     await requireAdmin(event);
 
-    const token =
-      event.cookies.get('sb-access-token') ??
-      event.request.headers.get('authorization')?.replace(/^Bearer\s+/i, '') ??
-      '';
-    const supabase = createClient(
-      import.meta.env.PUBLIC_SUPABASE_URL,
-      import.meta.env.PUBLIC_SUPABASE_ANON_KEY,
-      { global: { headers: { Authorization: `Bearer ${token}` } } }
-    );
+    const supabase = serverSupabase(event);
 
     const { error } = await supabase.rpc('apply_challenge_penalty', {
       p_challenge: challenge_id,

--- a/src/routes/admin/whoami/+server.ts
+++ b/src/routes/admin/whoami/+server.ts
@@ -1,17 +1,8 @@
 import { json } from '@sveltejs/kit';
-import { createClient } from '@supabase/supabase-js';
+import { serverSupabase } from '$lib/server/adminGuard';
 
 export async function GET(event) {
-  const token =
-    event.cookies.get('sb-access-token') ??
-    event.request.headers.get('authorization')?.replace(/^Bearer\s+/i, '') ??
-    '';
-  const supabase = createClient(
-    import.meta.env.PUBLIC_SUPABASE_URL,
-    import.meta.env.PUBLIC_SUPABASE_ANON_KEY,
-    { global: { headers: token ? { Authorization: `Bearer ${token}` } : {} } }
-  );
-
+  const supabase = serverSupabase(event);
   const { data: userData, error } = await supabase.auth.getUser();
   return json({
     hasCookieToken: Boolean(event.cookies.get('sb-access-token')),

--- a/src/routes/api/session/+server.ts
+++ b/src/routes/api/session/+server.ts
@@ -1,0 +1,30 @@
+import { json } from '@sveltejs/kit';
+
+export async function POST(event) {
+  let body: { access_token?: string; refresh_token?: string; expires_at?: number };
+  try {
+    body = await event.request.json();
+  } catch {
+    return json({ ok: false, error: 'JSON inv\xE0lid' }, { status: 400 });
+  }
+  const { access_token, refresh_token, expires_at } = body;
+  if (!access_token || !refresh_token || !expires_at) {
+    return json({ ok: false, error: 'Falten tokens o expiraci\xF3' }, { status: 400 });
+  }
+  const secure = event.url.protocol === 'https:';
+  const expires = new Date(expires_at * 1000);
+  const opts = { httpOnly: true, sameSite: 'lax' as const, path: '/', secure, expires };
+  event.cookies.set('sb-access-token', access_token, opts);
+  event.cookies.set('sb-refresh-token', refresh_token, opts);
+  event.cookies.set('sb-expires-at', String(expires_at), opts);
+  return json({ ok: true });
+}
+
+export function DELETE(event) {
+  const secure = event.url.protocol === 'https:';
+  const opts = { path: '/', secure, httpOnly: true, sameSite: 'lax' as const };
+  event.cookies.delete('sb-access-token', opts);
+  event.cookies.delete('sb-refresh-token', opts);
+  event.cookies.delete('sb-expires-at', opts);
+  return json({ ok: true });
+}

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -20,8 +20,21 @@
     try {
       loading = true;
       if (mode === 'login') {
-        const { error } = await supabase.auth.signInWithPassword({ email, password });
+        const { data, error } = await supabase.auth.signInWithPassword({ email, password });
         if (error) throw error;
+        const session = data?.session;
+        if (session) {
+          await fetch('/api/session', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify({
+              access_token: session.access_token,
+              refresh_token: session.refresh_token,
+              expires_at: session.expires_at
+            })
+          });
+        }
         okMsg = 'Sessió iniciada correctament.';
         await goto('/');   // redirigeix on vulguis
       } else {

--- a/src/routes/logout/+page.svelte
+++ b/src/routes/logout/+page.svelte
@@ -5,6 +5,7 @@
 
   onMount(async () => {
     await supabase.auth.signOut();
+    await fetch('/api/session', { method: 'DELETE', credentials: 'include' });
     goto('/');
   });
 </script>

--- a/src/routes/reptes/penalitzacions/+server.ts
+++ b/src/routes/reptes/penalitzacions/+server.ts
@@ -3,6 +3,10 @@ import { serverSupabase, requireAdmin } from '$lib/server/adminGuard';
 
 const PENALTY_TYPES = ['incompareixenca', 'desacord_dates'] as const;
 
+export function GET() {
+  return new Response(JSON.stringify({ error: 'Method not allowed' }), { status: 405 });
+}
+
 export async function POST(event) {
   const guard = await requireAdmin(event);
   if (guard) return guard; // 401/403/500


### PR DESCRIPTION
## Summary
- Store Supabase auth tokens in HTTP-only cookies and clear them on logout
- Reuse server-side Supabase helper for admin whoami and penalisation endpoints
- Enforce POST-only penalization endpoint with admin guard

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c3f5bf5a5c832eab8182a27f785615