### PR TITLE
Validate admin reset payload

### DIFF
--- a/src/routes/admin/reset/+server.ts
+++ b/src/routes/admin/reset/+server.ts
@@ -10,7 +10,17 @@ export async function POST(event) {
   if (guard) return guard; // 401/403/500
 
   const supabase = serverSupabase(event);
-  const { clearWaiting = false } = await event.request.json().catch(() => ({}));
+  let payload: { clearWaiting?: unknown };
+  try {
+    payload = await event.request.json();
+  } catch {
+    return json({ error: 'JSON invàlid' }, { status: 400 });
+  }
+
+  const { clearWaiting = false } = payload;
+  if (typeof clearWaiting !== 'boolean') {
+    return json({ error: 'clearWaiting ha de ser booleà' }, { status: 400 });
+  }
   const { data, error } = await supabase.rpc('reset_event_to_initial', {
     p_event: null,
     p_clear_waiting: !!clearWaiting


### PR DESCRIPTION
## Summary
- validate `/admin/reset` payload and return friendly 400 messages
- ensure admin reset leverages existing guard and server-side Supabase client

## Testing
- `pnpm check`


------
https://chatgpt.com/codex/tasks/task_e_68c54770b880832eb4694b4844c1195e