### PR TITLE
Unify server admin guard and credentialed client fetches

### DIFF
--- a/src/lib/server/adminGuard.ts
+++ b/src/lib/server/adminGuard.ts
@@ -36,12 +36,12 @@ export async function requireAdmin(event: Parameters<import('@sveltejs/kit').Req
   if (!email) {
     return new Response(JSON.stringify({ error: 'No autenticat' }), { status: 401 });
   }
-  const { data, error } = await supabase.rpc('is_admin', { email });
+  const { data, error } = await supabase.rpc('is_admin', { p_email: email });
   if (error) {
     return new Response(JSON.stringify({ error: error.message }), { status: 500 });
   }
   if (!data) {
-    return new Response(JSON.stringify({ error: 'No autoritzat' }), { status: 403 });
+    return new Response(JSON.stringify({ error: 'Només admins' }), { status: 403 });
   }
   return null; // ok
 }

--- a/src/routes/admin/debug/+server.ts
+++ b/src/routes/admin/debug/+server.ts
@@ -19,7 +19,8 @@ function decodeJwtPayload(token: string | null) {
 }
 
 export const GET: RequestHandler = async (event) => {
-  await requireAdmin(event);
+  const guard = await requireAdmin(event);
+  if (guard) return guard; // 401/403/500
 
   const token =
     event.cookies.get('sb-access-token') ??

--- a/src/routes/admin/penalitzacions/+server.ts
+++ b/src/routes/admin/penalitzacions/+server.ts
@@ -25,7 +25,8 @@ export const POST: RequestHandler = async (event) => {
       return json({ ok: false, error: 'Tipus no suportat' }, { status: 400 });
     }
 
-    await requireAdmin(event);
+    const guard = await requireAdmin(event);
+    if (guard) return guard; // 401/403/500
 
     const supabase = serverSupabase(event);
 

--- a/src/routes/admin/reptes/+page.svelte
+++ b/src/routes/admin/reptes/+page.svelte
@@ -186,11 +186,12 @@
       busy = r.id;
       error = null;
       okMsg = null;
-      const res = await fetch('/reptes/accepta', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ id: r.id, data_iso: iso })
-      });
+        const res = await fetch('/reptes/accepta', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ id: r.id, data_iso: iso })
+        });
       const out = await res.json();
       if (!out.ok) throw new Error(out.error || 'No s\u2019ha pogut programar');
       okMsg = okText('Repte programat correctament.');
@@ -207,11 +208,12 @@
       busy = r.id;
       error = null;
       okMsg = null;
-      const res = await fetch('/reptes/accepta', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ id: r.id, data_iso: null })
-      });
+        const res = await fetch('/reptes/accepta', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ id: r.id, data_iso: null })
+        });
       const out = await res.json();
       if (!out.ok) throw new Error(out.error || 'No s\u2019ha pogut acceptar');
       okMsg = okText('Repte acceptat.');

--- a/src/routes/admin/waiting-list/[id]/+server.ts
+++ b/src/routes/admin/waiting-list/[id]/+server.ts
@@ -1,26 +1,18 @@
 import type { RequestHandler } from './$types';
 import { json } from '@sveltejs/kit';
-import { requireAdmin } from '$lib/server/adminGuard';
-import { createClient } from '@supabase/supabase-js';
+import { requireAdmin, serverSupabase } from '$lib/server/adminGuard';
 
 export const DELETE: RequestHandler = async (event) => {
   try {
-    await requireAdmin(event);
+    const guard = await requireAdmin(event);
+    if (guard) return guard; // 401/403/500
 
     const id = event.params.id;
     if (!id) {
       return json({ ok: false, error: 'ID requerit' }, { status: 400 });
     }
 
-    const token =
-      event.cookies.get('sb-access-token') ??
-      event.request.headers.get('authorization')?.replace(/^Bearer\s+/i, '') ??
-      '';
-    const supabase = createClient(
-      import.meta.env.PUBLIC_SUPABASE_URL,
-      import.meta.env.PUBLIC_SUPABASE_ANON_KEY,
-      { global: { headers: { Authorization: `Bearer ${token}` } } }
-    );
+    const supabase = serverSupabase(event);
 
     const { error } = await supabase
       .from('waiting_list')

--- a/src/routes/admin/whoami/+server.ts
+++ b/src/routes/admin/whoami/+server.ts
@@ -1,7 +1,10 @@
 import { json } from '@sveltejs/kit';
-import { serverSupabase } from '$lib/server/adminGuard';
+import { serverSupabase, requireAdmin } from '$lib/server/adminGuard';
 
 export async function GET(event) {
+  const guard = await requireAdmin(event);
+  if (guard) return guard; // 401/403/500
+
   const supabase = serverSupabase(event);
   const { data: userData, error } = await supabase.auth.getUser();
   return json({


### PR DESCRIPTION
## Summary
- Centralize admin validation with consistent cookie/header token check and RPC `is_admin`
- Apply admin guard across admin routes, using shared `serverSupabase`
- Send credentials with admin challenge acceptance requests

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c54d9377a0832e87ee5643baecccfc