### PR TITLE
Use competition reset RPC and show summary

### DIFF
--- a/src/routes/admin/reset/+server.ts
+++ b/src/routes/admin/reset/+server.ts
@@ -12,8 +12,11 @@ export async function POST(event) {
   const supabase = serverSupabase(event);
   const { data, error } = await supabase.rpc('reset_full_competition');
   if (error) {
-    return json({ error: error.message }, { status: 500 });
+    return json(
+      { error: "No s'ha pogut reiniciar el campionat" },
+      { status: 500 }
+    );
   }
-  return json(data ?? {});
+  return json(data ?? {}, { status: 200 });
 }
 


### PR DESCRIPTION
## Summary
- Use Supabase RPC reset_full_competition from admin reset endpoint and return human-friendly error
- Show full reset summary in admin UI and refresh related data after reset

## Testing
- `pnpm check`


------
https://chatgpt.com/codex/tasks/task_e_68c5b1b9646c832e80995acb322ffd06