### PR TITLE
Limit reprogramming to single change for non-admins

### DIFF
--- a/src/routes/reptes/me/+page.svelte
+++ b/src/routes/reptes/me/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { onMount } from 'svelte';
-import { user } from '$lib/authStore';
+import { user, adminStore } from '$lib/authStore';
 import { getSettings, type AppSettings } from '$lib/settings';
 
 type Challenge = {
@@ -317,21 +317,25 @@ async function saveSchedule(r: Challenge) {
                   id={`schedule-${r.id}`}
                   value={scheduleLocal.get(r.id) ?? ''}
                   on:input={(e) => scheduleLocal.set(r.id, (e.target as HTMLInputElement).value)}
-                  disabled={busy === r.id}
+                  disabled={
+                    busy === r.id ||
+                    (!$adminStore && r.estat === 'programat' && r.reprogram_count >= 1)
+                  }
                 />
                 <p class="text-xs text-slate-500 mt-1">
                   La data ha d'estar dins de {settings.dies_jugar_despres_acceptar} dies.
                 </p>
-                {#if r.estat === 'programat' && r.reprogram_count >= 1}
-                  <p class="text-xs text-slate-500 mt-1">
-                    Has arribat al límit de reprogramacions. Només un administrador pot canviar-la de nou.
-                  </p>
+                {#if r.estat === 'programat' && r.reprogram_count >= 1 && !$adminStore}
+                  <p class="text-xs text-slate-500 mt-1">Ja has reprogramat un cop; cal administrador.</p>
                 {/if}
               </div>
               <button
                 class="rounded bg-blue-600 text-white px-3 py-1 h-9 disabled:opacity-60"
                 on:click={() => saveSchedule(r)}
-                disabled={busy === r.id}
+                disabled={
+                  busy === r.id ||
+                  (!$adminStore && r.estat === 'programat' && r.reprogram_count >= 1)
+                }
               >
                 {busy === r.id ? 'Desant…' : 'Desa data'}
               </button>

--- a/src/routes/reptes/programar/+server.ts
+++ b/src/routes/reptes/programar/+server.ts
@@ -34,11 +34,9 @@ export const POST: RequestHandler = async ({ request }) => {
       return json({ ok: false, error: 'Sessió invàlida' }, { status: 400 });
     }
 
-    const { data: adm, error: admErr } = await supabase
-      .from('admins')
-      .select('email')
-      .eq('email', auth.user.email)
-      .maybeSingle();
+    const { data: adm, error: admErr } = await supabase.rpc('is_admin', {
+      p_email: auth.user.email
+    });
     if (admErr) {
       if (isRlsError(admErr)) return json({ ok: false, error: 'Permisos insuficients' }, { status: 403 });
       return json({ ok: false, error: admErr.message }, { status: 400 });


### PR DESCRIPTION
## Summary
- Restrict `/reptes/programar` server handler to allow only one reschedule per non-admin using existing admin guard
- Disable scheduling controls for non-admins after one reprogram with clear messaging

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c5b203e604832e8720971605d13256