### PR TITLE
Validate challenge UUID and add quick penalty action

### DIFF
--- a/src/routes/admin/reptes/+page.svelte
+++ b/src/routes/admin/reptes/+page.svelte
@@ -277,6 +277,28 @@
     }
   }
 
+  async function penalitza(r: ChallengeRow) {
+    try {
+      busy = r.id;
+      error = null;
+      okMsg = null;
+      const res = await fetch('/reptes/penalitzacions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ challenge_id: r.id, tipus: 'incompareixenca' })
+      });
+      const js = await res.json();
+      if (!res.ok || !js.ok) throw new Error(js.error || 'Error aplicant penalització');
+      okMsg = okText('Penalització aplicada');
+      await load();
+    } catch (e) {
+      error = formatSupabaseError(e);
+    } finally {
+      busy = null;
+    }
+  }
+
   async function updateState(id: string, newState: ChallengeRow['estat'], also?: Record<string, any>) {
     try {
       busy = id;
@@ -374,6 +396,11 @@
                       on:click={() => cancel(r)}
                     >Anul·la</button>
                   {/if}
+                  <button
+                    class="rounded bg-rose-700 text-white px-3 py-1 text-xs disabled:opacity-60"
+                    disabled={busy === r.id}
+                    on:click={() => penalitza(r)}
+                  >Penalitza → Incompareixença</button>
                 </div>
               {/if}
             </td>

--- a/src/routes/reptes/penalitzacions/+server.ts
+++ b/src/routes/reptes/penalitzacions/+server.ts
@@ -22,6 +22,10 @@ export async function POST(event) {
   if (!challenge_id || !tipus) {
     return json({ error: 'Falten camps: challenge_id, tipus' }, { status: 400 });
   }
+  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  if (!UUID_RE.test(challenge_id)) {
+    return json({ error: 'challenge_id invàlid' }, { status: 400 });
+  }
   if (!PENALTY_TYPES.includes(tipus as any)) {
     return json({ error: 'Tipus no suportat' }, { status: 400 });
   }
@@ -32,6 +36,9 @@ export async function POST(event) {
     .eq('id', challenge_id)
     .maybeSingle();
   if (chalErr) {
+    if ((chalErr as any).code === '22P02') {
+      return json({ error: 'challenge_id invàlid' }, { status: 400 });
+    }
     return json({ error: "No s'ha pogut comprovar el repte" }, { status: 500 });
   }
   if (!chal) {


### PR DESCRIPTION
## Summary
- validate challenge_id UUID and return proper errors in penalty endpoint
- add quick "Penalitza → Incompareixença" action in admin challenge list

## Testing
- `pnpm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c5b2431ef4832e960f05412375ea61