### PR TITLE
Surface reset RPC errors

### DIFF
--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -177,7 +177,7 @@
         invalidateAll()
       ]);
     } catch (e) {
-      resetErr = formatSupabaseError(e);
+      resetErr = e instanceof Error ? e.message : formatSupabaseError(e);
     } finally {
       resetBusy = false;
     }

--- a/src/routes/admin/reset/+server.ts
+++ b/src/routes/admin/reset/+server.ts
@@ -11,12 +11,15 @@ export async function POST(event) {
 
   const supabase = serverSupabase(event);
   const { data, error } = await supabase.rpc('reset_full_competition');
+
   if (error) {
-    return json(
-      { error: "No s'ha pogut reiniciar el campionat" },
-      { status: 500 }
-    );
+    return json({ error: error.message }, { status: 500 });
   }
+
+  if (data && typeof data === 'object' && 'ok' in data && !data.ok) {
+    return json({ error: (data as any).error }, { status: 500 });
+  }
+
   return json(data ?? {}, { status: 200 });
 }
 


### PR DESCRIPTION
## Summary
- Return underlying `reset_full_competition` RPC error messages from the `/admin/reset` endpoint.
- Display server-provided error details in the admin UI when a reset fails.

## Testing
- ❌ `pnpm check` *(missing names `hasTB`, `j` in unrelated file)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b5340900832e844b6b0be06b2610