### PR TITLE
Enforce ladder challenge restrictions

### DIFF
--- a/supabase/sql/rpc_can_create_challenge.sql
+++ b/supabase/sql/rpc_can_create_challenge.sql
@@ -70,9 +70,10 @@ begin
     return;
   end if;
 
-  -- Rank gap check
-  if abs(v_pos_reptador - v_pos_reptat) > v_max_gap then
-    return query select false, 'Diferència de posicions massa gran';
+  -- Rank gap check: only challenge up to v_max_gap positions above
+  if (v_pos_reptador - v_pos_reptat) <= 0 or (v_pos_reptador - v_pos_reptat) > v_max_gap then
+    return query select false,
+      'Només es pot reptar fins a ' || v_max_gap || ' posicions per sobre';
     return;
   end if;
 


### PR DESCRIPTION
## Summary
- Ensure players can only challenge up to two higher-ranked positions

## Testing
- `npm run check` *(fails: Cannot find name 'penalitza', 'isWalkover', 'resultEnum', 'hasTB', 'j')*

------
https://chatgpt.com/codex/tasks/task_e_68c5c4743ba0832eac64638bdb00e5dd