### PR TITLE
Refactorització de lògica d'estats de reptes

### DIFF
--- a/src/routes/admin/reptes/+page.svelte
+++ b/src/routes/admin/reptes/+page.svelte
@@ -273,11 +273,7 @@
                       >Posar resultat</a>
                     {/if}
                   {/if}
-                  <button
-                    class="rounded bg-rose-700 text-white px-3 py-1 text-xs disabled:opacity-60"
-                    disabled={busy === r.id}
-                    on:click={() => penalitza(r)}
-                  >Penalitza → Incompareixença</button>
+                  
                 </div>
               {/if}
             </td>

--- a/src/routes/admin/reptes/[id]/resultat/+page.svelte
+++ b/src/routes/admin/reptes/[id]/resultat/+page.svelte
@@ -12,7 +12,7 @@
     reptat_id: string;
     pos_reptador: number | null;
     pos_reptat: number | null;
-    data_acceptacio: string | null;
+    data_programada: string | null;
     estat: 'proposat' | 'acceptat' | 'programat' | 'refusat' | 'caducat' | 'jugat' | 'anullat';
   };
 
@@ -39,6 +39,15 @@
 
   let data_joc_local = '';
 
+  $: isWalkover = tipusResultat !== 'normal';
+  $: hasTB = tipusResultat === 'normal' && tiebreak;
+
+  function resultEnum() {
+    if (tipusResultat !== 'normal') return tipusResultat;
+    if (tiebreak) return Number(tbR) > Number(tbT) ? 'empat_tiebreak_reptador' : 'empat_tiebreak_reptat';
+    return Number(carR) > Number(carT) ? 'guanya_reptador' : 'guanya_reptat';
+  }
+
   const id = $page.params.id;
 
   onMount(load);
@@ -57,7 +66,7 @@
 
       const { data: c, error: e1 } = await supabase
         .from('challenges')
-        .select('id,event_id,reptador_id,reptat_id,pos_reptador,pos_reptat,data_acceptacio,estat')
+        .select('id,event_id,reptador_id,reptat_id,pos_reptador,pos_reptat,data_programada,estat')
         .eq('id', id)
         .maybeSingle();
       if (e1) throw e1;
@@ -77,7 +86,7 @@
       reptadorNom = dict.get(c.reptador_id) ?? '—';
       reptatNom = dict.get(c.reptat_id) ?? '—';
 
-      data_joc_local = toLocalInput(c.data_acceptacio || new Date().toISOString());
+      data_joc_local = toLocalInput(c.data_programada || new Date().toISOString());
     } catch (e:any) {
       error = e?.message ?? 'Error carregant el repte';
     } finally {
@@ -205,7 +214,6 @@
         else rpcMsg = `Rànquing sense canvis${r?.reason ? ' (' + r.reason + ')' : ''}.`;
       }
       okMsg = 'Resultat desat correctament. Repte marcat com a "jugat".';
-      rpcMsg = j.rpcMsg ?? null;
     } catch (e:any) {
       error = e?.message ?? 'No s’ha pogut desar el resultat';
     } finally {

--- a/src/routes/reptes/[id]/resultat/+page.svelte
+++ b/src/routes/reptes/[id]/resultat/+page.svelte
@@ -13,7 +13,7 @@
     reptat_id: string;
     pos_reptador: number | null;
     pos_reptat: number | null;
-    data_acceptacio: string | null;
+    data_programada: string | null;
   };
 
   type Settings = {
@@ -64,7 +64,7 @@
       // 1) Carrega repte
       const { data: c, error: e1 } = await supabase
         .from('challenges')
-        .select('id,event_id,reptador_id,reptat_id,pos_reptador,pos_reptat,data_acceptacio')
+        .select('id,event_id,reptador_id,reptat_id,pos_reptador,pos_reptat,data_programada')
         .eq('id', id)
         .maybeSingle();
       if (e1) throw e1;
@@ -90,7 +90,7 @@
         .maybeSingle();
       if (cfg) settings = cfg;
 
-      data_joc_local = toLocalInput(c.data_acceptacio) || toLocalInput(new Date().toISOString());
+      data_joc_local = toLocalInput(c.data_programada) || toLocalInput(new Date().toISOString());
       } catch (e) {
         error = formatSupabaseError(e);
       } finally {

--- a/src/routes/reptes/programar/+server.ts
+++ b/src/routes/reptes/programar/+server.ts
@@ -45,7 +45,7 @@ export const POST: RequestHandler = async ({ request }) => {
 
     const { data: chal, error: chalErr } = await supabase
       .from('challenges')
-      .select('data_programada,reprogram_count,estat')
+      .select('data_programada,reprogram_count,estat,data_acceptacio')
       .eq('id', id)
       .maybeSingle();
     if (chalErr) {
@@ -72,6 +72,9 @@ export const POST: RequestHandler = async ({ request }) => {
     const updates: any = { data_programada: data_iso, estat: 'programat' };
     if (alreadyProgrammed) {
       updates.reprogram_count = (chal.reprogram_count ?? 0) + 1;
+    }
+    if (chal.estat === 'proposat') {
+      updates.data_acceptacio = new Date().toISOString();
     }
 
     const { data: upd, error: upErr } = await supabase

--- a/supabase/sql/rpc_apply_pre_inactivity.sql
+++ b/supabase/sql/rpc_apply_pre_inactivity.sql
@@ -24,7 +24,7 @@ begin
         where c.event_id = p_event
           and (c.reptador_id = rp.player_id or c.reptat_id = rp.player_id)
           and (
-            (c.estat = 'programat' and c.data_acceptacio >= now() - interval '21 days') or
+            (c.estat = 'programat' and c.data_programada >= now() - interval '21 days') or
             (c.estat = 'jugat' and m.data_joc >= now() - interval '21 days')
           )
       )

--- a/supabase/sql/rpc_program_challenge.sql
+++ b/supabase/sql/rpc_program_challenge.sql
@@ -9,9 +9,10 @@ declare
   v_old timestamptz;
   v_reprogram integer;
   v_is_admin boolean;
+  v_estat text;
 begin
-  select data_acceptacio, coalesce(reprogram_count,0)
-    into v_old, v_reprogram
+  select data_programada, coalesce(reprogram_count,0), estat
+    into v_old, v_reprogram, v_estat
     from challenges
     where id = p_challenge;
   if not found then
@@ -28,14 +29,16 @@ begin
       return;
     end if;
     update challenges
-      set data_acceptacio = p_when,
+      set data_programada = p_when,
           estat = 'programat',
-          reprogram_count = v_reprogram + 1
+          reprogram_count = v_reprogram + 1,
+          data_acceptacio = case when v_estat = 'proposat' then now() else data_acceptacio end
       where id = p_challenge;
   else
     update challenges
-      set data_acceptacio = p_when,
-          estat = 'programat'
+      set data_programada = p_when,
+          estat = 'programat',
+          data_acceptacio = case when v_estat = 'proposat' then now() else data_acceptacio end
       where id = p_challenge;
   end if;
 
@@ -44,3 +47,4 @@ end;
 $$;
 
 grant execute on function public.program_challenge(uuid, timestamp with time zone) to authenticated;
+


### PR DESCRIPTION
## Resum
- Unificar la programació de reptes amb `data_programada` i registrar l'acceptació quan s'assigna una data
- Adaptar la UI de jugadors i administradors a la nova gestió d'estats i eliminar la desprogramació
- Actualitzar les RPC i procediments perquè facin servir `data_programada` en comptes de `data_acceptacio`

## Proves
- `pnpm check`

------
https://chatgpt.com/codex/tasks/task_e_68c5c49533d4832eb96808f527a1622b