### PR TITLE
Implement voluntary dropout RPC

### DIFF
--- a/src/routes/reptes/baixa/+server.ts
+++ b/src/routes/reptes/baixa/+server.ts
@@ -42,126 +42,31 @@ export const POST: RequestHandler = async ({ request }) => {
     if (!event) {
       return json({ ok: false, error: 'No hi ha cap event actiu' }, { status: 400 });
     }
-    const event_id = event.id;
-
-    const { data: rp, error: rpErr } = await supabase
-      .from('ranking_positions')
-      .select('posicio')
-      .eq('event_id', event_id)
-      .eq('player_id', player.id)
-      .maybeSingle();
-    if (rpErr) {
-      if (isRlsError(rpErr)) return json({ ok: false, error: 'Permisos insuficients' }, { status: 403 });
-      return json({ ok: false, error: rpErr.message }, { status: 400 });
-    }
-    if (!rp) {
-      return json({ ok: false, error: 'No estàs inscrit a l’event actiu' }, { status: 400 });
-    }
-    const myPos = rp.posicio as number;
-
-    const { data: below, error: bErr } = await supabase
-      .from('ranking_positions')
-      .select('player_id,posicio')
-      .eq('event_id', event_id)
-      .gt('posicio', myPos)
-      .order('posicio', { ascending: true });
-    if (bErr) {
-      if (isRlsError(bErr)) return json({ ok: false, error: 'Permisos insuficients' }, { status: 403 });
-      return json({ ok: false, error: bErr.message }, { status: 400 });
-    }
-
-    const { error: delErr } = await supabase
-      .from('ranking_positions')
-      .delete()
-      .eq('event_id', event_id)
-      .eq('player_id', player.id);
-    if (delErr) {
-      if (isRlsError(delErr)) return json({ ok: false, error: 'Permisos insuficients' }, { status: 403 });
-      return json({ ok: false, error: delErr.message }, { status: 400 });
-    }
-
-    const history: any[] = [];
-    history.push({
-      event_id,
-      player_id: player.id,
-      posicio_anterior: myPos,
-      posicio_nova: null,
-      motiu: 'baixa',
-      ref_challenge: null
-    });
-
-    for (const b of below ?? []) {
-      const { error } = await supabase
+      const event_id = event.id;
+      const { data: rp, error: rpErr } = await supabase
         .from('ranking_positions')
-        .update({ posicio: (b.posicio as number) - 1 })
+        .select('posicio')
         .eq('event_id', event_id)
-        .eq('player_id', b.player_id);
-      if (error) {
-        if (isRlsError(error)) return json({ ok: false, error: 'Permisos insuficients' }, { status: 403 });
-        return json({ ok: false, error: error.message }, { status: 400 });
+        .eq('player_id', player.id)
+        .maybeSingle();
+      if (rpErr) {
+        if (isRlsError(rpErr)) return json({ ok: false, error: 'Permisos insuficients' }, { status: 403 });
+        return json({ ok: false, error: rpErr.message }, { status: 400 });
       }
-      history.push({
-        event_id,
-        player_id: b.player_id,
-        posicio_anterior: b.posicio,
-        posicio_nova: (b.posicio as number) - 1,
-        motiu: 'puja per baixa',
-        ref_challenge: null
+      if (!rp) {
+        return json({ ok: false, error: 'No estàs inscrit a l’event actiu' }, { status: 400 });
+      }
+
+      const { error: rpcErr } = await supabase.rpc('apply_voluntary_drop', {
+        p_event: event_id,
+        p_player: player.id
       });
-    }
-
-    const { data: wait, error: wErr } = await supabase
-      .from('waiting_list')
-      .select('player_id')
-      .eq('event_id', event_id)
-      .order('ordre', { ascending: true })
-      .limit(1)
-      .maybeSingle();
-    if (wErr) {
-      if (isRlsError(wErr)) return json({ ok: false, error: 'Permisos insuficients' }, { status: 403 });
-      return json({ ok: false, error: wErr.message }, { status: 400 });
-    }
-
-    if (wait?.player_id) {
-      const { error: insErr } = await supabase
-        .from('ranking_positions')
-        .insert({ event_id, player_id: wait.player_id, posicio: 20 });
-      if (insErr) {
-        if (isRlsError(insErr)) return json({ ok: false, error: 'Permisos insuficients' }, { status: 403 });
-        return json({ ok: false, error: insErr.message }, { status: 400 });
+      if (rpcErr) {
+        if (isRlsError(rpcErr)) return json({ ok: false, error: 'Permisos insuficients' }, { status: 403 });
+        return json({ ok: false, error: rpcErr.message }, { status: 400 });
       }
 
-      const { error: delWErr } = await supabase
-        .from('waiting_list')
-        .delete()
-        .eq('event_id', event_id)
-        .eq('player_id', wait.player_id);
-      if (delWErr) {
-        if (isRlsError(delWErr)) return json({ ok: false, error: 'Permisos insuficients' }, { status: 403 });
-        return json({ ok: false, error: delWErr.message }, { status: 400 });
-      }
-
-      history.push({
-        event_id,
-        player_id: wait.player_id,
-        posicio_anterior: null,
-        posicio_nova: 20,
-        motiu: 'entra per baixa',
-        ref_challenge: null
-      });
-    }
-
-    if (history.length) {
-      const { error: histErr } = await supabase
-        .from('history_position_changes')
-        .insert(history);
-      if (histErr) {
-        if (isRlsError(histErr)) return json({ ok: false, error: 'Permisos insuficients' }, { status: 403 });
-        return json({ ok: false, error: histErr.message }, { status: 400 });
-      }
-    }
-
-    return json({ ok: true, message: 'Baixa registrada' });
+      return json({ ok: true, message: 'Baixa registrada' });
   } catch (e: any) {
     return json({ ok: false, error: e?.message ?? 'Error intern' }, { status: 500 });
   }

--- a/supabase/sql/rpc_apply_voluntary_drop.sql
+++ b/supabase/sql/rpc_apply_voluntary_drop.sql
@@ -1,0 +1,57 @@
+create or replace function public.apply_voluntary_drop(
+  p_event uuid,
+  p_player uuid
+) returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  b record;
+  v_pos integer;
+  v_wait uuid;
+begin
+  select posicio into v_pos
+    from ranking_positions
+    where event_id = p_event and player_id = p_player;
+  if v_pos is null then
+    return;
+  end if;
+
+  delete from ranking_positions
+    where event_id = p_event and player_id = p_player;
+
+  insert into history_position_changes(event_id, player_id, posicio_anterior, posicio_nova, motiu, ref_challenge)
+    values (p_event, p_player, v_pos, null, 'baixa', null);
+
+  for b in
+    select player_id, posicio
+    from ranking_positions
+    where event_id = p_event and posicio > v_pos
+    order by posicio
+  loop
+    update ranking_positions
+      set posicio = b.posicio - 1
+      where event_id = p_event and player_id = b.player_id;
+    insert into history_position_changes(event_id, player_id, posicio_anterior, posicio_nova, motiu, ref_challenge)
+      values (p_event, b.player_id, b.posicio, b.posicio - 1, 'puja per baixa', null);
+  end loop;
+
+  select player_id into v_wait
+    from waiting_list
+    where event_id = p_event
+    order by ordre
+    limit 1;
+
+  if v_wait is not null then
+    insert into ranking_positions(event_id, player_id, posicio)
+      values (p_event, v_wait, 20);
+    delete from waiting_list
+      where event_id = p_event and player_id = v_wait;
+    insert into history_position_changes(event_id, player_id, posicio_anterior, posicio_nova, motiu, ref_challenge)
+      values (p_event, v_wait, null, 20, 'entra per baixa', null);
+  end if;
+end;
+$$;
+
+grant execute on function public.apply_voluntary_drop(uuid, uuid) to authenticated;


### PR DESCRIPTION
## Summary
- add SQL function `apply_voluntary_drop` to remove a player, shift ranking and record history
- simplify dropout endpoint to call the new RPC

## Testing
- `pnpm check` *(fails: Cannot find name 'hasTB')*

------
https://chatgpt.com/codex/tasks/task_e_68c5c4ec7e98832ea17ce359c5d071ab