### PR TITLE
Use RPC for challenge scheduling with reprogram limit

### DIFF
--- a/src/routes/reptes/me/+page.svelte
+++ b/src/routes/reptes/me/+page.svelte
@@ -220,14 +220,19 @@ async function saveSchedule(r: Challenge) {
   }
   try {
     busy = r.id;
-    const res = await fetch('/reptes/programar', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-      body: JSON.stringify({ id: r.id, data_iso: parsedIso })
+    const u = $user;
+    if (!u?.email) {
+      error = 'Has d\u2019iniciar sessi\u00f3.';
+      return;
+    }
+    const { supabase } = await import('$lib/supabaseClient');
+    const { data: out, error: rpcErr } = await supabase.rpc('programar_repte', {
+      p_challenge: r.id,
+      p_data: parsedIso,
+      p_actor_email: u.email
     });
-    const out = await res.json();
-    if (!out.ok) {
+    if (rpcErr) throw rpcErr;
+    if (!out?.ok) {
       const reason = out.error;
       if (reason === 'Només una reprogramació; contacta un administrador') {
         error = 'Aquest repte ja s\u2019ha reprogramat una vegada. Si cal canviar-ho de nou, contacta amb un administrador.';

--- a/supabase/sql/rpc_programar_repte.sql
+++ b/supabase/sql/rpc_programar_repte.sql
@@ -1,0 +1,50 @@
+create or replace function public.programar_repte(
+  p_challenge uuid,
+  p_data timestamp with time zone,
+  p_actor_email text
+) returns table(ok boolean, error text)
+language plpgsql
+security definer
+as $$
+declare
+  v_old timestamptz;
+  v_reprogram integer;
+  v_estat text;
+  v_is_admin boolean;
+begin
+  select data_programada, coalesce(reprogram_count,0), estat
+    into v_old, v_reprogram, v_estat
+    from challenges
+    where id = p_challenge;
+  if not found then
+    return query select false, 'Repte no trobat';
+    return;
+  end if;
+
+  select exists(select 1 from admins where email = p_actor_email)
+    into v_is_admin;
+
+  if v_old is not null and v_old <> p_data then
+    if not v_is_admin and v_reprogram >= 1 then
+      return query select false, 'Només una reprogramació; contacta un administrador';
+      return;
+    end if;
+    update challenges
+      set data_programada = p_data,
+          estat = 'programat',
+          reprogram_count = v_reprogram + 1,
+          data_acceptacio = case when v_estat = 'proposat' then now() else data_acceptacio end
+      where id = p_challenge;
+  else
+    update challenges
+      set data_programada = p_data,
+          estat = 'programat',
+          data_acceptacio = case when v_estat = 'proposat' then now() else data_acceptacio end
+      where id = p_challenge;
+  end if;
+
+  return query select true, null::text;
+end;
+$$;
+
+grant execute on function public.programar_repte(uuid, timestamp with time zone, text) to authenticated;


### PR DESCRIPTION
## Summary
- Schedule challenges through new `programar_repte` RPC
- Enforce single reprogram limit for non-admin users
- Call scheduling RPC from client pages and server endpoint

## Testing
- `pnpm check` *(fails: Duplicate function implementation in unrelated file)*

------
https://chatgpt.com/codex/tasks/task_e_68c670a4b554832eb8db36a76b036b34