### PR TITLE
Ensure matches inserts return generated id

### DIFF
--- a/src/routes/admin/reptes/[id]/resultat/+page.svelte
+++ b/src/routes/admin/reptes/[id]/resultat/+page.svelte
@@ -201,7 +201,11 @@
         insertRow.tiebreak_reptat   = null;
       }
 
-      const { error: e1 } = await supabase.from('matches').insert(insertRow);
+      const { error: e1 } = await supabase
+        .from('matches')
+        .insert(insertRow)
+        .select('id')
+        .single();
       if (e1) throw e1;
 
       const { data: upd, error: e2 } = await supabase

--- a/src/routes/admin/reptes/[id]/resultat/+server.ts
+++ b/src/routes/admin/reptes/[id]/resultat/+server.ts
@@ -105,7 +105,11 @@ export const POST: RequestHandler = async (event) => {
     motiu: isWalkover ? 'incompareixenca' : null,
   };
 
-  const { error: e1 } = await supabase.from('matches').insert(insertRow);
+  const { error: e1 } = await supabase
+    .from('matches')
+    .insert(insertRow)
+    .select('id')
+    .single();
   if (e1) return json({ ok: false, error: e1.message }, { status: 400 });
 
   const { error: e2 } = await supabase

--- a/src/routes/reptes/[id]/resultat/+page.svelte
+++ b/src/routes/reptes/[id]/resultat/+page.svelte
@@ -132,17 +132,21 @@
       const { supabase } = await import('$lib/supabaseClient');
 
       // 1) Inserir match
-      const { error: e1 } = await supabase.from('matches').insert({
-        challenge_id: id,
-        data_joc: data_iso,
-        caramboles_reptador: carR,
-        caramboles_reptat: carT,
-        entrades,
-        resultat,
-        tiebreak,
-        tiebreak_reptador: tiebreak ? tbR : null,
-        tiebreak_reptat: tiebreak ? tbT : null
-      });
+      const { error: e1 } = await supabase
+        .from('matches')
+        .insert({
+          challenge_id: id,
+          data_joc: data_iso,
+          caramboles_reptador: carR,
+          caramboles_reptat: carT,
+          entrades,
+          resultat,
+          tiebreak,
+          tiebreak_reptador: tiebreak ? tbR : null,
+          tiebreak_reptat: tiebreak ? tbT : null
+        })
+        .select('id')
+        .single();
       if (e1) throw e1;
 
       // 2) Update estat repte


### PR DESCRIPTION
## Summary
- ensure all match insertions fetch generated UUID
- keep history and ranking logic unchanged

## Testing
- `pnpm check` *(fails: Duplicate function implementation in src/routes/admin/reptes/+page.svelte)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a9fd7b88832ea1188bb659a476f8