### PR TITLE
fix: remove duplicate penalitza function

### DIFF
--- a/src/routes/admin/reptes/+page.svelte
+++ b/src/routes/admin/reptes/+page.svelte
@@ -35,11 +35,6 @@
   
   onMount(load);
 
-  // Funció temporal de penalització pendent d'implementació
-  function penalitza(r: ChallengeRow) {
-    console.warn('penalitza no implementat', r);
-  }
-
   function toLocalInput(iso: string | null) {
     if (!iso) return '';
     const d = new Date(iso);


### PR DESCRIPTION
## Summary
- remove leftover placeholder penalitza function so only implemented version remains

## Testing
- `pnpm run check`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6ab8ee764832ea28c99959b60ec3f