### PR TITLE
fix: configure project for Vercel deployment

### DIFF
--- a/src/routes/admin/reptes/+page.svelte
+++ b/src/routes/admin/reptes/+page.svelte
@@ -35,11 +35,6 @@
   
   onMount(load);
 
-  // Funció temporal de penalització pendent d'implementació
-  function penalitza(r: ChallengeRow) {
-    console.warn('penalitza no implementat', r);
-  }
-
   function toLocalInput(iso: string | null) {
     if (!iso) return '';
     const d = new Date(iso);

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,15 +1,14 @@
 import adapter from '@sveltejs/adapter-static';
 
 const dev = process.env.NODE_ENV === 'development';
+const vercel = !!process.env.VERCEL;
 // Substitueix EL_TEU_REPO pel nom real del teu repo GitHub Pages
-const base = dev ? '' : '/c3b';
+const base = dev || vercel ? '' : '/c3b';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
   kit: {
-    adapter: adapter({
-      fallback: '200.html'   // evita errors 404 refrescant rutes
-    }),
+    adapter: adapter(vercel ? {} : { fallback: '200.html' }), // evita errors 404 refrescant rutes
     paths: { base }
   }
 };

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "outputDirectory": "build"
+}


### PR DESCRIPTION
## Summary
- remove leftover placeholder penalitza function so only implemented version remains
- detect Vercel in SvelteKit config to avoid GitHub-specific base path and fallback
- add `vercel.json` pointing Vercel to the static `build` output

## Testing
- `pnpm run check`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6ab8ee764832ea28c99959b60ec3f