### PR TITLE
fix: configure vercel adapter for dynamic routes

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,4 +1,5 @@
-import adapter from '@sveltejs/adapter-static';
+import adapterStatic from '@sveltejs/adapter-static';
+import adapterAuto from '@sveltejs/adapter-auto';
 
 const dev = process.env.NODE_ENV === 'development';
 const vercel = !!process.env.VERCEL;
@@ -8,7 +9,9 @@ const base = dev || vercel ? '' : '/c3b';
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
   kit: {
-    adapter: adapter(vercel ? {} : { fallback: '200.html' }), // evita errors 404 refrescant rutes
+    adapter: vercel
+      ? adapterAuto()
+      : adapterStatic({ fallback: '200.html' }), // evita errors 404 refrescant rutes
     paths: { base }
   }
 };

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,0 @@
-{
-  "outputDirectory": "build"
-}


### PR DESCRIPTION
## Summary
- switch to `adapter-auto` on Vercel while keeping static adapter elsewhere
- remove outdated `vercel.json`

## Testing
- `pnpm run check`
- `VERCEL=1 pnpm run build` *(fails: Could not install @sveltejs/adapter-vercel due to missing registry credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68c6adc291b8832ebc17c134ba09a331