### PR TITLE
Fix event query on admin challenge creation page

### DIFF
--- a/src/routes/admin/reptes/nou/+page.svelte
+++ b/src/routes/admin/reptes/nou/+page.svelte
@@ -72,7 +72,7 @@ import type { SupabaseClient } from '@supabase/supabase-js';
       // 2) Event actiu
       const { data: ev, error: eEvent } = await supabase
         .from('events')
-        .select('id, nom, any_temporada')
+        .select('id, nom')
         .eq('actiu', true)
         .limit(1)
         .maybeSingle();


### PR DESCRIPTION
## Summary
- Remove reference to non-existent `any_temporada` column when retrieving active event

## Testing
- `pnpm check`


------
https://chatgpt.com/codex/tasks/task_e_68c6bfc27294832e81692adf003f808b