### PR TITLE
Add registration form and player registration procedure

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -28,6 +28,7 @@
       <a href="/reptes" class={isActive("/reptes", $page.url.pathname)}>Reptes</a>
 
       {#if $authReady && $user}
+        <a href="/inscripcio" class={isActive("/inscripcio", $page.url.pathname)}>Inscripció</a>
         <a href="/reptes/me" class={isActive("/reptes/me", $page.url.pathname)}>Els meus reptes</a>
         <a href="/reptes/nou" class={isActive("/reptes/nou", $page.url.pathname)}>Crear repte</a>
       {/if}
@@ -71,6 +72,7 @@
       <a href="/reptes" class={isActive("/reptes", $page.url.pathname)}>Reptes</a>
 
       {#if $authReady && $user}
+        <a href="/inscripcio" class={isActive("/inscripcio", $page.url.pathname)}>Inscripció</a>
         <a href="/reptes/me" class={isActive("/reptes/me", $page.url.pathname)}>Els meus reptes</a>
         <a href="/reptes/nou" class={isActive("/reptes/nou", $page.url.pathname)}>Crear repte</a>
       {/if}

--- a/src/routes/inscripcio/+page.svelte
+++ b/src/routes/inscripcio/+page.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+  import { user } from '$lib/authStore';
+  import { invalidate } from '$app/navigation';
+
+  let loading = false;
+  let error: string | null = null;
+  let ok: string | null = null;
+
+  async function inscriure() {
+    try {
+      loading = true;
+      error = null;
+      ok = null;
+      const u = $user;
+      if (!u?.email) {
+        error = 'Has d\u2019iniciar sessi\u00f3.';
+        return;
+      }
+      const { supabase } = await import('$lib/supabaseClient');
+      const { data: ev, error: eEv } = await supabase
+        .from('events')
+        .select('id')
+        .eq('actiu', true)
+        .limit(1)
+        .maybeSingle();
+      if (eEv) throw eEv;
+      const eventId = ev?.id;
+      if (!eventId) {
+        error = 'No hi ha cap campionat actiu.';
+        return;
+      }
+      const { data: pl, error: ePl } = await supabase
+        .from('players')
+        .select('id')
+        .eq('email', u.email)
+        .maybeSingle();
+      if (ePl) throw ePl;
+      if (!pl) {
+        error = 'Email sense jugador associat.';
+        return;
+      }
+      const { data: res, error: eRpc } = await supabase.rpc('register_player', {
+        p_event: eventId,
+        p_player: pl.id
+      });
+      if (eRpc) throw eRpc;
+      const r: any = res;
+      if (!r?.ok) {
+        error = r?.error || 'Error desconegut';
+        return;
+      }
+      if (r.waiting) {
+        ok = `Inscrit a la llista d\u2019espera (ordre ${r.ordre})`;
+      } else {
+        ok = `Inscrit al r\u00e0nquing (posici\u00f3 ${r.posicio})`;
+      }
+      await Promise.all([
+        invalidate('/classificacio'),
+        invalidate('/llista-espera')
+      ]);
+    } catch (e: any) {
+      error = e?.message ?? 'Error desconegut';
+    } finally {
+      loading = false;
+    }
+  }
+</script>
+
+<svelte:head>
+  <title>Inscripci\u00f3</title>
+</svelte:head>
+
+<h1 class="text-2xl font-semibold mb-4">Inscripci\u00f3</h1>
+
+{#if $user}
+  <button
+    class="rounded bg-slate-800 px-4 py-2 text-white disabled:opacity-50"
+    disabled={loading}
+    on:click={inscriure}
+  >
+    {loading ? 'Processant…' : 'Inscriu-me'}
+  </button>
+  {#if error}
+    <div class="mt-4 rounded border border-red-200 bg-red-50 p-3 text-red-700">{error}</div>
+  {/if}
+  {#if ok}
+    <div class="mt-4 rounded border border-green-200 bg-green-50 p-3 text-green-700">{ok}</div>
+  {/if}
+{:else}
+  <p>Cal iniciar sessi\u00f3 per inscriure's.</p>
+{/if}

--- a/src/routes/inscripcio/+page.ts
+++ b/src/routes/inscripcio/+page.ts
@@ -1,0 +1,2 @@
+export const ssr = false;
+export const prerender = false;

--- a/supabase/sql/rpc_register_player.sql
+++ b/supabase/sql/rpc_register_player.sql
@@ -1,0 +1,68 @@
+create or replace function public.register_player(
+  p_event uuid,
+  p_player uuid
+) returns json
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_has_challenge boolean;
+  v_rank_count integer;
+  v_pos integer;
+  v_wait integer;
+begin
+  -- already in ranking?
+  if exists(select 1 from ranking_positions where event_id = p_event and player_id = p_player) then
+    return json_build_object('ok', false, 'error', 'Jugador ja inscrit al r\u00e0nquing');
+  end if;
+  if exists(select 1 from waiting_list where event_id = p_event and player_id = p_player) then
+    return json_build_object('ok', false, 'error', 'Jugador ja en llista d\u2019espera');
+  end if;
+
+  select count(*) > 0 into v_has_challenge from challenges where event_id = p_event;
+  select count(*) into v_rank_count from ranking_positions where event_id = p_event;
+
+  if not v_has_challenge then
+    -- initial phase: order by average
+    if v_rank_count >= 20 then
+      return json_build_object('ok', false, 'error', 'R\u00e0nquing complet');
+    end if;
+    insert into ranking_positions(event_id, posicio, player_id)
+      values (p_event, v_rank_count + 1, p_player);
+    with ranks as (
+      select rp.id,
+             row_number() over(order by p.mitjana desc nulls last, rp.posicio) as new_pos
+      from ranking_positions rp
+      join players p on p.id = rp.player_id
+      where rp.event_id = p_event
+    )
+    update ranking_positions rp
+      set posicio = r.new_pos
+      from ranks r
+      where rp.id = r.id;
+    select posicio into v_pos from ranking_positions where event_id = p_event and player_id = p_player;
+    return json_build_object('ok', true, 'posicio', v_pos, 'waiting', false);
+  else
+    -- competition already started
+    if v_rank_count < 20 then
+      select min(pos) into v_pos from (
+        select generate_series(1,20) as pos
+        except
+        select posicio from ranking_positions where event_id = p_event
+      ) s;
+      if v_pos is null then v_pos := v_rank_count + 1; end if;
+      insert into ranking_positions(event_id, posicio, player_id)
+        values (p_event, v_pos, p_player);
+      return json_build_object('ok', true, 'posicio', v_pos, 'waiting', false);
+    else
+      select coalesce(max(ordre),0) + 1 into v_wait from waiting_list where event_id = p_event;
+      insert into waiting_list(event_id, player_id, ordre)
+        values (p_event, p_player, v_wait);
+      return json_build_object('ok', true, 'ordre', v_wait, 'waiting', true);
+    end if;
+  end if;
+end;
+$$;
+
+grant execute on function public.register_player(uuid, uuid) to authenticated;


### PR DESCRIPTION
## Summary
- add `register_player` SQL procedure to place new players in ranking or waiting list based on competition state
- create `/inscripcio` page that allows logged-in members to sign up and shows resulting position
- expose new Inscripció link in navigation

## Testing
- `pnpm check`


------
https://chatgpt.com/codex/tasks/task_e_68c6c4c08964832e97ce435d3356d5ed