### PR TITLE
Add waiting list link to navbar

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -26,6 +26,7 @@
       <a href="/calendari" class={isActive("/calendari", $page.url.pathname)}>Calendari</a>
       <a href="/classificacio" class={isActive("/classificacio", $page.url.pathname)}>Classificació</a>
       <a href="/reptes" class={isActive("/reptes", $page.url.pathname)}>Reptes</a>
+      <a href="/llista-espera" class={isActive("/llista-espera", $page.url.pathname)}>Llista d'espera</a>
       <a href="/historial" class={isActive("/historial", $page.url.pathname)}>Historial</a>
 
       {#if $authReady && $user}
@@ -71,6 +72,7 @@
       <a href="/calendari" class={isActive("/calendari", $page.url.pathname)}>Calendari</a>
       <a href="/classificacio" class={isActive("/classificacio", $page.url.pathname)}>Classificació</a>
       <a href="/reptes" class={isActive("/reptes", $page.url.pathname)}>Reptes</a>
+      <a href="/llista-espera" class={isActive("/llista-espera", $page.url.pathname)}>Llista d'espera</a>
       <a href="/historial" class={isActive("/historial", $page.url.pathname)}>Historial</a>
 
       {#if $authReady && $user}


### PR DESCRIPTION
## Summary
- show waiting list link in main layout navigation for desktop and mobile

## Testing
- `pnpm check`

------
https://chatgpt.com/codex/tasks/task_e_68c6d59a87a4832ea491ec6b2b96c77f