### PR TITLE
Replace is_admin RPC with admins table checks

### DIFF
--- a/src/lib/server/adminGuard.ts
+++ b/src/lib/server/adminGuard.ts
@@ -36,7 +36,12 @@ export async function requireAdmin(event: Parameters<import('@sveltejs/kit').Req
   if (!email) {
     return new Response(JSON.stringify({ error: 'No autenticat' }), { status: 401 });
   }
-  const { data, error } = await supabase.rpc('is_admin', { p_email: email });
+  const { data, error } = await supabase
+    .from('admins')
+    .select('email')
+    .eq('email', email)
+    .limit(1)
+    .maybeSingle();
   if (error) {
     return new Response(JSON.stringify({ error: error.message }), { status: 500 });
   }

--- a/src/routes/reptes/nou/+server.ts
+++ b/src/routes/reptes/nou/+server.ts
@@ -46,13 +46,16 @@ export const POST: RequestHandler = async ({ request }) => {
       return json({ ok: false, error: 'Sessió no iniciada' }, { status: 401 });
     }
 
-    const { data: isAdm, error: admErr } = await supabase.rpc('is_admin', {
-      p_email: auth.user.email
-    });
+    const { data: adminRow, error: admErr } = await supabase
+      .from('admins')
+      .select('email')
+      .eq('email', auth.user.email)
+      .limit(1)
+      .maybeSingle();
     if (admErr) {
       return json({ ok: false, error: admErr.message }, { status: 400 });
     }
-    const isAdmin = !!isAdm;
+    const isAdmin = !!adminRow;
 
     let reptadorId = reptador_id;
     if (!isAdmin) {


### PR DESCRIPTION
## Summary
- verify admin status by selecting from `admins` table instead of missing `is_admin` RPC
- adjust new challenge creation endpoint to use same admin check logic

## Testing
- `pnpm check`

------
https://chatgpt.com/codex/tasks/task_e_68c6f963f650832ebb0679c866005349