### PR TITLE
Remove challenge columns from classification table

### DIFF
--- a/src/routes/classificacio/+page.svelte
+++ b/src/routes/classificacio/+page.svelte
@@ -194,8 +194,6 @@
           <th class="px-3 py-2 text-left font-semibold">Mitjana</th>
           <th class="px-3 py-2 text-left font-semibold">Estat</th>
           <th class="px-3 py-2 text-left font-semibold">Assignat</th>
-          <th class="px-3 py-2 text-left font-semibold">Reptar</th>
-          <th class="px-3 py-2 text-left font-semibold">Reptable</th>
         </tr>
       </thead>
       <tbody>
@@ -231,18 +229,6 @@
             <td class="px-3 py-2">{r.mitjana ?? '-'}</td>
             <td class="px-3 py-2 capitalize">{r.estat.replace('_', ' ')}</td>
             <td class="px-3 py-2">{fmtSafe(r.assignat_el)}</td>
-            <td class="px-3 py-2">
-              <span
-                class={`text-xs rounded px-2 py-0.5 ${r.canReptar ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-500'}`}
-                >{r.canReptar ? 'Sí' : 'No'}</span
-              >
-            </td>
-            <td class="px-3 py-2">
-              <span
-                class={`text-xs rounded px-2 py-0.5 ${r.canSerReptat ? 'bg-blue-100 text-blue-800' : 'bg-gray-100 text-gray-500'}`}
-                >{r.canSerReptat ? 'Sí' : 'No'}</span
-              >
-            </td>
           </tr>
         {/each}
       </tbody>


### PR DESCRIPTION
## Summary
- Drop the "Reptar" and "Reptable" columns from the classification table, relying on icons next to player names.

## Testing
- `pnpm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c6fa8bfe50832e9080175619f7e341