### PR TITLE
feat: add ranking challenge badges

### DIFF
--- a/src/routes/classificacio/+page.svelte
+++ b/src/routes/classificacio/+page.svelte
@@ -10,11 +10,11 @@
     mitjana: number | null;
     estat: string;
     assignat_el: string | null;
-    canReptar?: boolean;
-    canSerReptat?: boolean;
     isMe?: boolean;
     hasActiveChallenge?: boolean;
-
+    onCooldown?: boolean;
+    canReptar?: boolean;
+    reptable?: boolean;
   };
 
   const fmtSafe = (iso: string | null): string => {
@@ -49,11 +49,11 @@
         const base = (data as Row[]) ?? [];
         rows = base.map((r) => ({
           ...r,
-          canReptar: false,
-          canSerReptat: false,
-
           isMe: myPlayerId === r.player_id,
-          hasActiveChallenge: false
+          hasActiveChallenge: false,
+          onCooldown: false,
+          canReptar: false,
+          reptable: false
         }));
 
         const eventId = base[0]?.event_id as string | undefined;
@@ -76,34 +76,49 @@
     eventId: string | undefined
   ): Promise<void> {
     if (!eventId) return;
+
+    const MAX_UP_CHALLENGE = 2;
+    const COOLDOWN_DAYS = 7;
+
     const byId = new Map<string, Row>();
     rows.forEach((r) => byId.set(r.player_id, r));
 
+    // Active challenges
     const { data: active } = await supabase
       .from('challenges')
-      .select('reptador_id, reptat_id')
+      .select('challenger_id, challenged_id')
       .eq('event_id', eventId)
-      .in('estat', ['proposat', 'acceptat', 'programat']);
+      .in('status', ['PENDING', 'ACCEPTED']);
     const activeIds = new Set<string>();
     (active as any[] ?? []).forEach((c) => {
-      activeIds.add((c as any).reptador_id);
-      activeIds.add((c as any).reptat_id);
+      activeIds.add((c as any).challenger_id);
+      activeIds.add((c as any).challenged_id);
     });
     activeIds.forEach((id) => {
       const row = byId.get(id);
       if (row) row.hasActiveChallenge = true;
     });
 
-    const { data: played } = await supabase
-      .from('matches')
-      .select('challenge:challenge_id(reptador_id, reptat_id)')
-      .eq('challenge.event_id', eventId);
-    const playedIds = new Set<string>();
-    (played as any[] ?? []).forEach((m) => {
-      const ch = (m as any).challenge;
-      if (ch) {
-        playedIds.add(ch.reptador_id);
-        playedIds.add(ch.reptat_id);
+    // Last challenge info
+    const { data: last } = await supabase
+      .from('player_last_challenge')
+      .select('player_id, last_challenge_date, last_challenge_outcome, was_challenger')
+      .eq('event_id', eventId);
+    const lastMap = new Map<string, any>();
+    (last as any[] ?? []).forEach((l) => lastMap.set(l.player_id, l));
+
+    const now = Date.now();
+    rows.forEach((r) => {
+      const lc = lastMap.get(r.player_id);
+      r.onCooldown = false;
+      if (lc?.last_challenge_date) {
+        const dt = new Date(lc.last_challenge_date);
+        const diff = (now - dt.getTime()) / (1000 * 60 * 60 * 24);
+        if (diff < COOLDOWN_DAYS) {
+          if (!(lc.last_challenge_outcome === 'REFUSED' && lc.was_challenger)) {
+            r.onCooldown = true;
+          }
+        }
       }
     });
 
@@ -111,65 +126,46 @@
     const ranking = rows.filter((r) => r.posicio != null && r.posicio <= 20);
     ranking.forEach((r) => byPos.set(r.posicio as number, r));
 
-    const maxGap = 2;
-    const tasks: Promise<void>[] = [];
+    // Determine who can challenge
+    ranking.forEach((r) => {
+      if (r.hasActiveChallenge || r.onCooldown) return;
+      for (let d = 1; d <= MAX_UP_CHALLENGE; d++) {
+        const opp = byPos.get((r.posicio as number) - d);
+        if (!opp) continue;
+        if (!opp.hasActiveChallenge && !opp.onCooldown) {
+          r.canReptar = true;
+          break;
+        }
+      }
+    });
 
-    for (const r of ranking) {
-      tasks.push(
-        (async () => {
-          if (r.hasActiveChallenge) return;
-          if (!playedIds.has(r.player_id)) {
-            r.canReptar = true;
-            r.canSerReptat = true;
-            return;
-          }
-          for (let d = 1; d <= maxGap; d++) {
-            const opp = byPos.get((r.posicio as number) - d);
-            if (!opp) continue;
-            const { data } = await supabase.rpc('can_create_challenge', {
-              p_event: eventId,
-              p_reptador: r.player_id,
-              p_reptat: opp.player_id
-            });
-            if ((data as any)?.[0]?.ok) {
-              r.canReptar = true;
-              break;
-            }
-          }
+    // Determine who can be challenged
+    ranking.forEach((r) => {
+      if (r.hasActiveChallenge || r.onCooldown) return;
+      for (let d = 1; d <= MAX_UP_CHALLENGE; d++) {
+        const challenger = byPos.get((r.posicio as number) + d);
+        if (!challenger) continue;
+        if (!challenger.hasActiveChallenge && !challenger.onCooldown) {
+          r.reptable = true;
+          break;
+        }
+      }
+    });
 
-          for (let d = 1; d <= maxGap; d++) {
-            const challenger = byPos.get((r.posicio as number) + d);
-            if (!challenger) continue;
-            const { data } = await supabase.rpc('can_create_challenge', {
-              p_event: eventId,
-              p_reptador: challenger.player_id,
-              p_reptat: r.player_id
-            });
-            if ((data as any)?.[0]?.ok) {
-              r.canSerReptat = true;
-              break;
-            }
-          }
-        })()
-      );
-    }
-
-    await Promise.all(tasks);
-
+    // Waiting list vs position 20
     const waiting = rows.filter((r) => r.posicio == null || r.posicio > 20);
     const firstWaiting = waiting[0];
     const pos20 = byPos.get(20);
-
-    if (firstWaiting && pos20 && !firstWaiting.hasActiveChallenge) {
-      const { data } = await supabase.rpc('can_create_access_challenge', {
-        p_event: eventId,
-        p_reptador: firstWaiting.player_id,
-        p_reptat: pos20.player_id
-      });
-      if ((data as any)?.[0]?.ok) {
-        firstWaiting.canReptar = true;
-        pos20.canSerReptat = true;
-      }
+    if (
+      firstWaiting &&
+      pos20 &&
+      !firstWaiting.hasActiveChallenge &&
+      !firstWaiting.onCooldown &&
+      !pos20.hasActiveChallenge &&
+      !pos20.onCooldown
+    ) {
+      firstWaiting.canReptar = true;
+      pos20.reptable = true;
     }
   }
 </script>
@@ -201,29 +197,41 @@
           <tr class="border-t">
             <td class="px-3 py-2">{r.posicio ?? '-'}</td>
             <td class="px-3 py-2">
-
               {r.nom}
-              {#if r.canReptar}
-                <span title="Pot reptar" class="ml-1 inline-block h-3 w-3 rounded-full bg-green-500 align-middle"></span>
+              {#if r.hasActiveChallenge}
+                <span
+                  title="Té repte actiu"
+                  class="ml-1 inline-block rounded bg-red-500 px-1 text-xs font-semibold text-white align-middle"
+                  >Té repte actiu</span
+                >
               {/if}
-              {#if r.canSerReptat}
-                <span title="Pot ser reptat" class="ml-1 inline-block h-3 w-3 rounded-full bg-blue-500 align-middle"></span>
-
+              {#if !r.hasActiveChallenge && r.onCooldown}
+                <span
+                  title="No pot reptar (cooldown)"
+                  class="ml-1 inline-block rounded bg-yellow-300 px-1 text-xs font-semibold text-slate-900 align-middle"
+                  >No pot reptar</span
+                >
+              {/if}
+              {#if !r.hasActiveChallenge && !r.onCooldown && r.canReptar}
+                <span
+                  title="Pot reptar"
+                  class="ml-1 inline-block rounded bg-green-500 px-1 text-xs font-semibold text-white align-middle"
+                  >Pot reptar</span
+                >
+              {/if}
+              {#if !r.hasActiveChallenge && !r.onCooldown && r.reptable}
+                <span
+                  title="Reptable"
+                  class="ml-1 inline-block rounded bg-blue-500 px-1 text-xs font-semibold text-white align-middle"
+                  >Reptable</span
+                >
               {/if}
               {#if r.isMe}
                 <span
                   title="Tu"
-
                   class="ml-1 inline-block rounded bg-yellow-400 px-1 text-xs font-semibold text-slate-900 align-middle"
                   >Tu</span
                 >
-
-              {/if}
-              {#if r.hasActiveChallenge}
-                <span
-                  title="Té un repte actiu"
-                  class="ml-1 inline-block h-3 w-3 rounded-full bg-red-500 align-middle"
-                ></span>
               {/if}
             </td>
             <td class="px-3 py-2">{r.mitjana ?? '-'}</td>
@@ -234,15 +242,27 @@
       </tbody>
     </table>
   </div>
-  <div class="mt-2 flex gap-4 text-sm">
-    <div class="flex items-center gap-1"><span class="inline-block h-3 w-3 rounded-full bg-green-500"></span><span>pot reptar</span></div>
-    <div class="flex items-center gap-1"><span class="inline-block h-3 w-3 rounded-full bg-blue-500"></span><span>pot ser reptat</span></div>
-
+  <div class="mt-2 flex flex-wrap gap-4 text-sm">
+    <div class="flex items-center gap-1">
+      <span class="inline-block rounded bg-red-500 px-1 text-xs font-semibold text-white">Té repte actiu</span>
+      <span>té repte actiu</span>
+    </div>
+    <div class="flex items-center gap-1">
+      <span class="inline-block rounded bg-yellow-300 px-1 text-xs font-semibold text-slate-900">No pot reptar</span>
+      <span>no pot reptar (cooldown)</span>
+    </div>
+    <div class="flex items-center gap-1">
+      <span class="inline-block rounded bg-green-500 px-1 text-xs font-semibold text-white">Pot reptar</span>
+      <span>pot reptar</span>
+    </div>
+    <div class="flex items-center gap-1">
+      <span class="inline-block rounded bg-blue-500 px-1 text-xs font-semibold text-white">Reptable</span>
+      <span>reptable</span>
+    </div>
     <div class="flex items-center gap-1">
       <span class="inline-block rounded bg-yellow-400 px-1 text-xs font-semibold text-slate-900">Tu</span>
       <span>tu</span>
     </div>
-    <div class="flex items-center gap-1"><span class="inline-block h-3 w-3 rounded-full bg-red-500"></span><span>repte actiu</span></div>
   </div>
 
 {/if}


### PR DESCRIPTION
## Summary
- compute challenge availability and cooldown from active and last challenges
- show badges for active challenge, cooldown, can challenge, and challengeable players in ranking

## Testing
- `pnpm check`

------
https://chatgpt.com/codex/tasks/task_e_68c6fb431ebc832e8d470a7745f67b97