### PR TITLE
Add automatic ranking refresh after match result

### DIFF
--- a/src/lib/components/Toasts.svelte
+++ b/src/lib/components/Toasts.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import { toasts, type Toast } from '$lib/ui/toastStore';
+</script>
+
+<div class="fixed top-2 right-2 flex flex-col gap-2 z-50">
+  {#each $toasts as t (t.id)}
+    <div
+      class="px-3 py-2 rounded text-white shadow"
+      class:bg-slate-800={t.type === 'info'}
+      class:bg-green-600={t.type === 'success'}
+      class:bg-red-600={t.type === 'error'}
+    >
+      {t.message}
+    </div>
+  {/each}
+</div>

--- a/src/lib/ui/toastStore.ts
+++ b/src/lib/ui/toastStore.ts
@@ -1,0 +1,17 @@
+import { writable } from 'svelte/store';
+
+export type Toast = {
+  id: number;
+  message: string;
+  type: 'info' | 'success' | 'error';
+};
+
+export const toasts = writable<Toast[]>([]);
+
+export function addToast(message: string, type: Toast['type'] = 'info', timeout = 3000) {
+  const id = Date.now();
+  toasts.update((t) => [...t, { id, message, type }]);
+  setTimeout(() => {
+    toasts.update((t) => t.filter((x) => x.id !== id));
+  }, timeout);
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,6 +3,7 @@
   import { onMount } from "svelte";
   import { user, authReady, initAuth, logout } from "$lib/authStore";
   import { adminStore } from '$lib/roles';
+  import Toasts from '$lib/components/Toasts.svelte';
 
   let showInscripcio = false;
 
@@ -173,6 +174,8 @@
 <main class="mx-auto max-w-5xl p-2 sm:p-4">
   <slot />
 </main>
+
+<Toasts />
 
 <!-- DEBUG opcional: treu-ho quan vulguis -->
 {#if $authReady}

--- a/src/routes/reptes/[id]/resultat/+page.svelte
+++ b/src/routes/reptes/[id]/resultat/+page.svelte
@@ -5,6 +5,8 @@
       import { checkIsAdmin } from '$lib/roles';
     import Banner from '$lib/components/Banner.svelte';
     import { formatSupabaseError, ok as okText, err as errText } from '$lib/ui/alerts';
+    import { refreshRanking } from '$lib/rankingStore';
+    import { addToast } from '$lib/ui/toastStore';
 
   type Challenge = {
     id: string;
@@ -198,6 +200,8 @@
         rpcMsg = r?.swapped
           ? okText('Rànquing actualitzat: intercanvi de posicions fet.')
           : okText(`Rànquing sense canvis${r?.reason ? ' (' + r.reason + ')' : ''}.`);
+        await refreshRanking();
+        addToast('Rànquing actualitzat', 'success');
       }
 
       okMsg = okText('Resultat desat correctament. Repte marcat com a jugat.');


### PR DESCRIPTION
## Summary
- add toast store/component and global container
- refresh ranking and show toast after saving a match result

## Testing
- `npm test` *(fails: vitest not installed)*
- `npm run check` *(fails: cannot find module 'vitest')*


------
https://chatgpt.com/codex/tasks/task_e_68c723fa83e0832ea9458d157301da52