### PR TITLE
chore: centralize RPC error handling

### DIFF
--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,65 @@
+export const ERROR_MESSAGES: Record<string, string> = {
+  'No es pot reptar a un mateix': 'No et pots reptar a tu mateix',
+  'no_self_challenge': 'No et pots reptar a tu mateix',
+  "L'event no és actiu": 'Event inactiu',
+  event_inactive: 'Event inactiu',
+  'El reptador no és un jugador actiu': 'Reptador inactiu',
+  challenger_inactive: 'Reptador inactiu',
+  'El reptat no és un jugador actiu': 'Reptat inactiu',
+  challenged_inactive: 'Reptat inactiu',
+  "El reptador no està al rànquing de l'event": 'El reptador no és al rànquing',
+  challenger_not_in_ranking: 'El reptador no és al rànquing',
+  "El reptat no està al rànquing de l'event": 'El reptat no és al rànquing',
+  challenged_not_in_ranking: 'El reptat no és al rànquing',
+  rank_gap_too_big: 'Diferència de posicions massa gran',
+  active_challenge_exists: 'Ja hi ha un repte actiu',
+  cooldown_min_not_met: 'Temps mínim entre reptes no complert',
+  cooldown_max_exceeded: 'Temps màxim entre reptes excedit',
+  no_player_behind: 'No es pot aplicar la penalització: no hi ha cap jugador darrere…'
+};
+
+export function mapError(reason?: string | null): string | undefined {
+  if (!reason) return reason ?? undefined;
+  const direct = ERROR_MESSAGES[reason];
+  if (direct) return direct;
+  if (reason.startsWith('Només es pot reptar')) {
+    return ERROR_MESSAGES['rank_gap_too_big'];
+  }
+  if (reason.startsWith("Has d'esperar")) {
+    return ERROR_MESSAGES['cooldown_min_not_met'];
+  }
+  if (reason.startsWith('El reptador o el reptat ja té un repte actiu')) {
+    return ERROR_MESSAGES['active_challenge_exists'];
+  }
+  if (reason.startsWith("S'ha excedit el temps màxim")) {
+    return ERROR_MESSAGES['cooldown_max_exceeded'];
+  }
+  if (reason.startsWith('No hi ha cap jugador darrere')) {
+    return ERROR_MESSAGES['no_player_behind'];
+  }
+  return reason;
+}
+
+export function wrapRpc<T extends { rpc: Function }>(client: T): T {
+  const original = client.rpc.bind(client);
+  client.rpc = async (fn: string, params?: any, options?: any) => {
+    const res = await original(fn, params, options);
+    if (res?.error?.message) {
+      res.error.message = mapError(res.error.message);
+    }
+    const apply = (obj: any) => {
+      if (obj && typeof obj === 'object') {
+        if ('reason' in obj && typeof obj.reason === 'string') {
+          obj.reason = mapError(obj.reason);
+        }
+        if ('warning' in obj && typeof obj.warning === 'string') {
+          obj.warning = mapError(obj.warning);
+        }
+      }
+    };
+    if (Array.isArray(res?.data)) res.data.forEach(apply);
+    else apply(res?.data);
+    return res;
+  };
+  return client;
+}

--- a/src/lib/server/adminGuard.ts
+++ b/src/lib/server/adminGuard.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
+import { wrapRpc } from '../errors';
 
 function tokenFromEvent(event: Parameters<import('@sveltejs/kit').RequestHandler>[0]) {
   return (
@@ -13,10 +14,12 @@ export function serverSupabase(
   token?: string | null
 ) {
   const t = token ?? tokenFromEvent(event) ?? undefined;
-  return createClient(
-    import.meta.env.PUBLIC_SUPABASE_URL,
-    import.meta.env.PUBLIC_SUPABASE_ANON_KEY,
-    { global: { headers: t ? { Authorization: `Bearer ${t}` } : {} } }
+  return wrapRpc(
+    createClient(
+      import.meta.env.PUBLIC_SUPABASE_URL,
+      import.meta.env.PUBLIC_SUPABASE_ANON_KEY,
+      { global: { headers: t ? { Authorization: `Bearer ${t}` } : {} } }
+    )
   );
 }
 

--- a/src/lib/server/supabaseAdmin.ts
+++ b/src/lib/server/supabaseAdmin.ts
@@ -1,6 +1,7 @@
 // src/lib/server/supabaseAdmin.ts
 import { createClient } from '@supabase/supabase-js';
 import { getSupabaseEnv } from './env';
+import { wrapRpc } from '../errors';
 
 export function serverSupabase(req?: Request) {
   const { url, key } = getSupabaseEnv();
@@ -10,11 +11,13 @@ export function serverSupabase(req?: Request) {
     req?.headers.get('Authorization') ||
     null;
 
-  return createClient(url, key, {
-    auth: { persistSession: false, autoRefreshToken: false },
-    global: {
-      headers: authHeader ? { Authorization: authHeader } : {}
-    }
-  });
+  return wrapRpc(
+    createClient(url, key, {
+      auth: { persistSession: false, autoRefreshToken: false },
+      global: {
+        headers: authHeader ? { Authorization: authHeader } : {}
+      }
+    })
+  );
 }
 

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,5 +1,6 @@
 // src/lib/supabaseClient.ts
 import { createClient } from '@supabase/supabase-js';
+import { wrapRpc } from './errors';
 
 const url = import.meta.env.PUBLIC_SUPABASE_URL;
 const anon = import.meta.env.PUBLIC_SUPABASE_ANON_KEY;
@@ -7,9 +8,11 @@ const anon = import.meta.env.PUBLIC_SUPABASE_ANON_KEY;
 if (!url) throw new Error('PUBLIC_SUPABASE_URL no definit');
 if (!anon) throw new Error('PUBLIC_SUPABASE_ANON_KEY no definit');
 
-export const supabase = createClient(url, anon, {
-  auth: {
-    persistSession: true,
-    autoRefreshToken: true
-  }
-});
+export const supabase = wrapRpc(
+  createClient(url, anon, {
+    auth: {
+      persistSession: true,
+      autoRefreshToken: true
+    }
+  })
+);

--- a/src/routes/admin/debug/+server.ts
+++ b/src/routes/admin/debug/+server.ts
@@ -3,6 +3,7 @@ import type { RequestHandler } from './$types';
 import { json } from '@sveltejs/kit';
 import { requireAdmin } from '$lib/server/adminGuard';
 import { createClient } from '@supabase/supabase-js';
+import { wrapRpc } from '$lib/errors';
 
 // decodifica (sense verificar) la part payload d'un JWT
 function decodeJwtPayload(token: string | null) {
@@ -33,10 +34,12 @@ export const GET: RequestHandler = async (event) => {
   let rls_ok = false;
   let rls_error: string | null = null;
   try {
-    const supabase = createClient(
-      import.meta.env.PUBLIC_SUPABASE_URL,
-      import.meta.env.PUBLIC_SUPABASE_ANON_KEY,
-      { global: { headers: { Authorization: `Bearer ${token ?? ''}` } } }
+    const supabase = wrapRpc(
+      createClient(
+        import.meta.env.PUBLIC_SUPABASE_URL,
+        import.meta.env.PUBLIC_SUPABASE_ANON_KEY,
+        { global: { headers: { Authorization: `Bearer ${token ?? ''}` } } }
+      )
     );
     const { error } = await supabase
       .from('admins')

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mapError, wrapRpc } from '../src/lib/errors';
+
+describe('error mapping', () => {
+  const cases: [string, string][] = [
+    ['No es pot reptar a un mateix', 'No et pots reptar a tu mateix'],
+    ["L'event no és actiu", 'Event inactiu'],
+    ['El reptador no és un jugador actiu', 'Reptador inactiu'],
+    ['El reptat no és un jugador actiu', 'Reptat inactiu'],
+    ["El reptador no està al rànquing de l'event", 'El reptador no és al rànquing'],
+    ["El reptat no està al rànquing de l'event", 'El reptat no és al rànquing'],
+    ['Només es pot reptar fins a 2 posicions per sobre', 'Diferència de posicions massa gran'],
+    ['El reptador o el reptat ja té un repte actiu', 'Ja hi ha un repte actiu'],
+    ["Has d'esperar 3 dies més", 'Temps mínim entre reptes no complert'],
+    ["S'ha excedit el temps màxim entre reptes jugats", 'Temps màxim entre reptes excedit'],
+    ['no_player_behind', 'No es pot aplicar la penalització: no hi ha cap jugador darrere…'],
+    ['No hi ha cap jugador darrere', 'No es pot aplicar la penalització: no hi ha cap jugador darrere…']
+  ];
+
+  for (const [input, output] of cases) {
+    it(`maps "${input}"`, () => {
+      expect(mapError(input)).toBe(output);
+    });
+  }
+
+  it('wrapRpc maps error and reason', async () => {
+    const rpc = vi.fn().mockResolvedValue({
+      data: { ok: false, reason: 'No es pot reptar a un mateix', warning: "S'ha excedit el temps màxim entre reptes jugats" },
+      error: { message: "Has d'esperar 1 dies més" }
+    });
+    const client: any = { rpc };
+    wrapRpc(client);
+    const res = await client.rpc('fn');
+    expect(res.error.message).toBe('Temps mínim entre reptes no complert');
+    expect(res.data.reason).toBe('No et pots reptar a tu mateix');
+    expect(res.data.warning).toBe('Temps màxim entre reptes excedit');
+  });
+});


### PR DESCRIPTION
## Summary
- add error mapping module for human-friendly copy
- wrap Supabase RPC calls to apply unified error messages
- cover error mapping with tests

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c725022528832e860c45fae387cb8b