### PR TITLE
refactor: central auth store with roles

### DIFF
--- a/src/lib/components/Nav.svelte
+++ b/src/lib/components/Nav.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { page } from '$app/stores';
-  import { user, logout } from '$lib/authStore';
-  import { adminStore } from '$lib/roles';
+    import { user, logout, adminStore } from '$lib/authStore';
 
   // enllaços sempre visibles
   const baseLinks = [

--- a/src/lib/roles.ts
+++ b/src/lib/roles.ts
@@ -1,11 +1,8 @@
 // src/lib/roles.ts
-import { writable } from 'svelte/store';
 import { supabase } from '$lib/supabaseClient';
 
 const CACHE_TTL_MS = 60 * 1000;
 let cache: { value: boolean; ts: number } | null = null;
-
-export const adminStore = writable<boolean>(false);
 
 export function invalidateAdminCache(): void {
   cache = null;
@@ -41,15 +38,8 @@ export async function checkIsAdmin(): Promise<boolean> {
     cache = { value: false, ts: now };
     return false;
   }
-  const val = !!data;
-  cache = { value: val, ts: now };
-  return val;
-}
-
-export async function refreshAdmin(): Promise<boolean> {
-  invalidateAdminCache();
-  const val = await checkIsAdmin();
-  adminStore.set(val);
-  return val;
-}
+    const val = !!data;
+    cache = { value: val, ts: now };
+    return val;
+  }
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
   import "../app.css";
   import { onMount } from "svelte";
-  import { user, authReady, initAuth, logout } from "$lib/authStore";
-  import { adminStore } from '$lib/roles';
+    import { user, status, initAuth, logout, adminStore } from "$lib/authStore";
   import Toasts from '$lib/components/Toasts.svelte';
 
   let showInscripcio = false;
@@ -76,9 +75,9 @@
   let menuOpen = false;
   const toggleMenu = () => (menuOpen = !menuOpen);
 
-  $: if ($authReady) {
-    void refreshInscripcioVisibility($user);
-  }
+    $: if ($status === 'authenticated') {
+      void refreshInscripcioVisibility($user);
+    }
 </script>
 
 <nav class="bg-slate-900 text-white">
@@ -92,7 +91,7 @@
       <a href="/llista-espera" class={isActive("/llista-espera", $page.url.pathname)}>Llista d'espera</a>
       <a href="/historial" class={isActive("/historial", $page.url.pathname)}>Historial</a>
 
-      {#if $authReady && $user}
+        {#if $status === 'authenticated' && $user}
         {#if showInscripcio}
           <a href="/inscripcio" class={isActive("/inscripcio", $page.url.pathname)}>Inscripció</a>
         {/if}
@@ -100,14 +99,14 @@
         <a href="/reptes/nou" class={isActive("/reptes/nou", $page.url.pathname)}>Crear repte</a>
       {/if}
 
-      {#if $authReady && $adminStore}
+        {#if $status === 'authenticated' && $adminStore}
         <a href="/admin" class={isActive("/admin", $page.url.pathname)}>Admin</a>
       {/if}
 
       <div class="ml-auto flex items-center gap-3">
-        {#if !$authReady}
-          <span class="text-sm opacity-80">…</span>
-        {:else if $user}
+          {#if $status === 'loading'}
+            <span class="text-sm opacity-80">…</span>
+          {:else if $user}
           <span class="text-sm opacity-80">{$user.email}</span>
           <button
             class="rounded border px-3 py-1 text-sm hover:bg-slate-800"
@@ -140,7 +139,7 @@
       <a href="/llista-espera" class={isActive("/llista-espera", $page.url.pathname)}>Llista d'espera</a>
       <a href="/historial" class={isActive("/historial", $page.url.pathname)}>Historial</a>
 
-      {#if $authReady && $user}
+        {#if $status === 'authenticated' && $user}
         {#if showInscripcio}
           <a href="/inscripcio" class={isActive("/inscripcio", $page.url.pathname)}>Inscripció</a>
         {/if}
@@ -148,14 +147,14 @@
         <a href="/reptes/nou" class={isActive("/reptes/nou", $page.url.pathname)}>Crear repte</a>
       {/if}
 
-      {#if $authReady && $adminStore}
+        {#if $status === 'authenticated' && $adminStore}
         <a href="/admin" class={isActive("/admin", $page.url.pathname)}>Admin</a>
       {/if}
 
-      <div class="pt-2 flex flex-col gap-2">
-        {#if !$authReady}
-          <span class="text-sm opacity-80">…</span>
-        {:else if $user}
+        <div class="pt-2 flex flex-col gap-2">
+          {#if $status === 'loading'}
+            <span class="text-sm opacity-80">…</span>
+          {:else if $user}
           <span class="text-sm opacity-80">{$user.email}</span>
           <button
             class="w-fit rounded border px-3 py-1 text-sm hover:bg-slate-800"
@@ -178,7 +177,7 @@
 <Toasts />
 
 <!-- DEBUG opcional: treu-ho quan vulguis -->
-{#if $authReady}
+  {#if $status !== 'loading'}
   <div class="fixed bottom-2 right-2 text-xs bg-slate-800 text-white px-2 py-1 rounded">
     {$user?.email ?? "anònim"} | admin: {$adminStore ? "sí" : "no"}
   </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
-  import { user, authReady } from '$lib/authStore';
+    import { user, status } from '$lib/authStore';
   import { getSettings, type AppSettings } from '$lib/settings';
   import { get } from 'svelte/store';
 
@@ -25,15 +25,15 @@
   let settings: AppSettings;
 
   onMount(() => {
-    const unsub = authReady.subscribe(async (ready) => {
-      if (!ready) return;
-      const u = get(user);
-      if (!u?.email) {
-        goto('/ranking');
-        loading = false;
-        unsub();
-        return;
-      }
+      const unsub = status.subscribe(async (s) => {
+        if (s === 'loading') return;
+        const u = get(user);
+        if (s === 'anonymous' || !u?.email) {
+          goto('/ranking');
+          loading = false;
+          unsub();
+          return;
+        }
       try {
         const { supabase } = await import('$lib/supabaseClient');
         settings = await getSettings();

--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -1,23 +1,12 @@
 <script lang="ts">
-    import { onMount } from 'svelte';
-    import { adminStore, checkIsAdmin } from '$lib/roles';
+  import { adminStore } from '$lib/authStore';
+</script>
 
-    let checked = false;
-
-    onMount(async () => {
-      const ok = await checkIsAdmin();
-      checked = true;
-      if (!ok) {
-        // adminStore remains false; unauthorized message will show
-      }
-    });
-  </script>
-
-  {#if $adminStore}
-    <slot />
-  {:else if checked}
-    <div class="m-4 rounded border border-red-300 bg-red-50 p-4 text-red-800">
-      No autoritzat — <a href="/" class="underline">Inici</a>
-    </div>
-  {/if}
+{#if $adminStore}
+  <slot />
+{:else}
+  <div class="m-4 rounded border border-red-300 bg-red-50 p-4 text-red-800">
+    No autoritzat — <a href="/" class="underline">Inici</a>
+  </div>
+{/if}
 

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { goto, invalidateAll, invalidate } from '$app/navigation';
-  import { user } from '$lib/authStore';
-  import { checkIsAdmin, adminStore } from '$lib/roles';
+    import { user, adminStore } from '$lib/authStore';
+    import { checkIsAdmin } from '$lib/roles';
   import Banner from '$lib/components/Banner.svelte';
   import Loader from '$lib/components/Loader.svelte';
   import { formatSupabaseError, err as errText } from '$lib/ui/alerts';

--- a/src/routes/admin/historial/+page.svelte
+++ b/src/routes/admin/historial/+page.svelte
@@ -4,7 +4,7 @@
   import Banner from '$lib/components/Banner.svelte';
   import { supabase } from '$lib/supabaseClient';
   import { formatSupabaseError } from '$lib/ui/alerts';
-  import { adminStore } from '$lib/roles';
+    import { adminStore } from '$lib/authStore';
 
   type Change = {
     creat_el: string;

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { supabase } from '$lib/supabaseClient';
-  import { authReady, user } from '$lib/authStore';
+    import { status, user } from '$lib/authStore';
 
   let mode: 'login' | 'signup' = 'login';
   let email = '';
@@ -82,7 +82,7 @@
   <div class="rounded border border-green-300 bg-green-50 text-green-800 p-3 mb-3">{okMsg}</div>
 {/if}
 
-{#if $authReady && $user}
+  {#if $status === 'authenticated' && $user}
   <p class="text-slate-600">Ja has iniciat sessió com <strong>{$user.email}</strong>.</p>
 {:else}
   <form class="max-w-sm space-y-3" on:submit|preventDefault={onSubmit}>

--- a/src/routes/ranking/+page.svelte
+++ b/src/routes/ranking/+page.svelte
@@ -5,7 +5,7 @@
   import { canCreateChallenge } from '$lib/canCreateChallenge';
   import { ranking, refreshRanking, type RankingRow } from '$lib/rankingStore';
   import PlayerEvolutionModal from '$lib/components/PlayerEvolutionModal.svelte';
-  import { adminStore } from '$lib/roles';
+    import { adminStore } from '$lib/authStore';
   import { applyDisagreementDrop } from '$lib/applyDisagreementDrop';
 
   type RowState = RankingRow & {


### PR DESCRIPTION
## Summary
- centralize session, profile and role handling in `authStore`
- update layouts and pages to use loading/authenticated state
- guard admin routes via shared `adminStore`

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c727ba409c832e880d9835a9e60be8