### PR TITLE
Hide date proposal for non participants

### DIFF
--- a/src/lib/challenges.ts
+++ b/src/lib/challenges.ts
@@ -1,5 +1,18 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 
+export type ChallengeParticipants = {
+  reptador_id: string | null;
+  reptat_id: string | null;
+};
+
+export function isParticipant(
+  mePlayerId: string | null,
+  repte: ChallengeParticipants | null | undefined
+): boolean {
+  if (!mePlayerId || !repte) return false;
+  return mePlayerId === repte.reptador_id || mePlayerId === repte.reptat_id;
+}
+
 export async function acceptChallenge(supabase: SupabaseClient, id: string): Promise<void> {
   const { error } = await supabase
     .from('challenges')

--- a/src/lib/components/PropostaDataForm.svelte
+++ b/src/lib/components/PropostaDataForm.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { supabase } from '$lib/supabaseClient';
   import Banner from '$lib/components/Banner.svelte';
+  import { isParticipant } from '$lib/challenges';
 
   export let challengeId: string;
   export let reptadorId: string | null = null;
@@ -58,7 +59,10 @@
     if (error || !me?.id) { canShow = false; return; }
 
     await ensureChallengeParties();
-    canShow = !!(me.id && (me.id === reptadorId || me.id === reptatId));
+    canShow = isParticipant(me.id ?? null, {
+      reptador_id: reptadorId,
+      reptat_id: reptatId
+    });
   }
 
   $: computeCanShow(); // re-calcula si canvien props

--- a/src/routes/reptes/+page.svelte
+++ b/src/routes/reptes/+page.svelte
@@ -2,7 +2,12 @@
     import { onMount } from 'svelte';
     import { user } from '$lib/stores/auth';
     import type { SupabaseClient } from '@supabase/supabase-js';
-    import { acceptChallenge, refuseChallenge, scheduleChallenge } from '$lib/challenges';
+    import {
+      acceptChallenge,
+      refuseChallenge,
+      scheduleChallenge,
+      isParticipant
+    } from '$lib/challenges';
 
   type Challenge = {
     id: string;
@@ -222,7 +227,7 @@
                 </button>
               </div>
             {/if}
-            {#if r.estat !== 'refusat'}
+            {#if myPlayerId && isParticipant(myPlayerId, r) && r.estat !== 'refusat'}
               <div class="mt-2 flex gap-2 items-center">
                 <input
                   type="datetime-local"


### PR DESCRIPTION
## Summary
- add reusable `isParticipant` helper
- hide schedule controls for non-participants in challenge list
- use helper in `PropostaDataForm` to guard date proposal

## Testing
- `npm test` *(fails: Cannot convert undefined or null to object)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b1b84a38832ea09c470a2c6dbab7