### PR TITLE
Use authFetch helper in Svelte components

### DIFF
--- a/src/lib/components/PropostaDataForm.svelte
+++ b/src/lib/components/PropostaDataForm.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { supabase } from '$lib/supabaseClient';
   import Banner from '$lib/components/Banner.svelte';
+  import { authFetch } from '$lib/utils/http';
 
   export let challengeId: string;
   export let reptadorId: string | null = null;
@@ -11,22 +12,10 @@
   let err: string | null = null;
   let ok: string | null = null;
 
-  // Helper: obtenir Authorization Bearer del Supabase
-  async function getAuthHeader(): Promise<Record<string, string>> {
-    try {
-      const { data } = await supabase.auth.getSession();
-      const token = data?.session?.access_token ?? null;
-      return token ? { Authorization: `Bearer ${token}` } : {};
-    } catch { return {}; }
-  }
-
   async function ensureChallengeParties() {
     // Si no han arribat per props, els busquem
     if (reptadorId && reptatId) return;
-    const res = await fetch(`/reptes/detall/${challengeId}`, { // adapta si tens un altre endpoint
-      headers: await getAuthHeader(),
-      credentials: 'include'
-    });
+    const res = await authFetch(`/reptes/detall/${challengeId}`); // adapta si tens un altre endpoint
     const j = await res.json();
     if (res.ok) {
       reptadorId = j.reptador_id;
@@ -70,13 +59,8 @@
 
     submitting = true;
     try {
-      const res = await fetch('/reptes/proposa-data', {
+      const res = await authFetch('/reptes/proposa-data', {
         method: 'POST',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(await getAuthHeader())
-        },
         body: JSON.stringify({ challenge_id: challengeId, data_programada: iso })
       });
       const body = await res.json().catch(() => ({}));

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -7,6 +7,7 @@
   import Loader from '$lib/components/Loader.svelte';
   import { formatSupabaseError, err as errText } from '$lib/ui/alerts';
   import { runDeadlines } from '$lib/deadlinesService';
+  import { authFetch } from '$lib/utils/http';
 
   let loading = true;
   let error: string | null = null;
@@ -83,10 +84,8 @@
       penaltyBusy = true;
       penaltyOk = null;
       penaltyErr = null;
-      const res = await fetch('/reptes/penalitzacions', {
+      const res = await authFetch('/reptes/penalitzacions', {
         method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        credentials: 'include',
         body: JSON.stringify({ challenge_id, tipus })
       });
       const js = await res.json();
@@ -177,9 +176,8 @@
       resetBusy = true;
       resetOk = null;
       resetErr = null;
-      const res = await fetch('/admin/reset', {
-        method: 'POST',
-        credentials: 'include'
+      const res = await authFetch('/admin/reset', {
+        method: 'POST'
       });
       const js = await res.json();
       if (!res.ok || js.error || !js.ok)

--- a/src/routes/admin/reptes/+page.svelte
+++ b/src/routes/admin/reptes/+page.svelte
@@ -6,6 +6,7 @@
         import Banner from '$lib/components/Banner.svelte';
         import Loader from '$lib/components/Loader.svelte';
       import { formatSupabaseError, ok as okText, err as errText } from '$lib/ui/alerts';
+      import { authFetch } from '$lib/utils/http';
 
 
   type ChallengeRow = {
@@ -148,10 +149,8 @@
       busy = r.id;
       error = null;
       okMsg = null;
-        const res = await fetch('/reptes/accepta', {
+        const res = await authFetch('/reptes/accepta', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          credentials: 'include',
           body: JSON.stringify({ id: r.id, data_iso: null })
         });
       const out = await res.json();

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -2,6 +2,7 @@
     import { goto } from '$app/navigation';
     import { supabase } from '$lib/supabaseClient';
     import { status, user } from '$lib/stores/auth';
+    import { authFetch } from '$lib/utils/http';
 
   let mode: 'login' | 'signup' = 'login';
   let email = '';
@@ -24,10 +25,8 @@
         if (error) throw error;
         const session = data?.session;
         if (session) {
-          await fetch('/api/session', {
+          await authFetch('/api/session', {
             method: 'POST',
-            headers: { 'content-type': 'application/json' },
-            credentials: 'include',
             body: JSON.stringify({
               access_token: session.access_token,
               refresh_token: session.refresh_token,

--- a/src/routes/reptes/me/+page.svelte
+++ b/src/routes/reptes/me/+page.svelte
@@ -3,6 +3,7 @@
   import { user, adminStore } from '$lib/stores/auth';
   import { getSettings, type AppSettings } from '$lib/settings';
   import { checkIsAdmin } from '$lib/roles';
+  import { authFetch } from '$lib/utils/http';
 
 type Challenge = {
   id: string;
@@ -207,10 +208,8 @@ async function accept(r: Challenge) {
   }
   try {
     busy = r.id;
-    const res = await fetch('/reptes/accepta', {
+    const res = await authFetch('/reptes/accepta', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
       body: JSON.stringify({ id: r.id, data_iso: sel })
     });
     const out = await res.json();
@@ -230,10 +229,8 @@ async function refuse(r: Challenge) {
   try {
     const motiu = (refuseReason.get(r.id) ?? '').trim() || null;
     busy = r.id;
-    const res = await fetch('/reptes/refusa', {
+    const res = await authFetch('/reptes/refusa', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
       body: JSON.stringify({ id: r.id, motiu })
     });
     const out = await res.json();
@@ -258,10 +255,8 @@ async function counter(r: Challenge) {
   }
   try {
     busy = r.id;
-    const res = await fetch('/reptes/contraproposta', {
+    const res = await authFetch('/reptes/contraproposta', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
       body: JSON.stringify({ id: r.id, dates_iso: dates })
     });
     const out = await res.json();


### PR DESCRIPTION
## Summary
- Use `authFetch` wrapper on client-side calls so Authorization and JSON headers are sent automatically
- Ensure challenge creation, scheduling, and admin actions send Bearer tokens

## Testing
- `pnpm test` *(fails: TypeError: Cannot convert undefined or null to object)*
- `pnpm check`


------
https://chatgpt.com/codex/tasks/task_e_68c7b1c5cae4832e9a4ba54d3c9b4d93