### PR TITLE
Use admin maintenance RPC for deadlines sweep

### DIFF
--- a/src/lib/deadlinesService.ts
+++ b/src/lib/deadlinesService.ts
@@ -1,18 +1,76 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 
-export type RunDeadlinesResult = {
-  ok: boolean;
-  caducats_sense_acceptar: number;
-  anullats_sense_jugar: number;
+export type MaintenanceLogEntry = {
+  challenges_processed?: number | null;
+  challengesProcessed?: number | null;
+  inactivity_processed?: number | null;
+  inactivityProcessed?: number | null;
+  [key: string]: unknown;
 };
 
-export async function runDeadlines(
-  supabase: SupabaseClient
-): Promise<RunDeadlinesResult> {
-  const { data, error } = await supabase.rpc('run_challenge_deadlines');
-  if (error) throw new Error(error.message);
-  const result = Array.isArray(data) ? data[0] : data;
-  if (!result) throw new Error('No result');
-  return result as RunDeadlinesResult;
+export type RunDeadlinesResult = {
+  challengesProcessed: number;
+  inactivityProcessed: number;
+  raw: MaintenanceLogEntry[];
+};
+
+const DEFAULT_ACTOR = 'admin:webapp';
+const CHALLENGE_KEYS = ['challenges_processed', 'challengesProcessed'];
+const INACTIVITY_KEYS = ['inactivity_processed', 'inactivityProcessed'];
+
+function ensureArray<T>(value: T | T[] | null | undefined): T[] {
+  if (Array.isArray(value)) return value;
+  if (value == null) return [];
+  return [value];
 }
 
+function extractCount(entry: MaintenanceLogEntry, keys: string[]): number {
+  for (const key of keys) {
+    const value = entry[key];
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value;
+    }
+    if (typeof value === 'string') {
+      const parsed = Number.parseInt(value, 10);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+  }
+  return 0;
+}
+
+export async function runOverdueSweep(
+  supabase: SupabaseClient
+): Promise<MaintenanceLogEntry[]> {
+  const { data, error } = await supabase.rpc(
+    'sweep_overdue_challenges_from_settings_mvp2'
+  );
+  if (error) throw new Error(error.message);
+  return ensureArray<MaintenanceLogEntry>(data);
+}
+
+export async function runDeadlines(
+  supabase: SupabaseClient,
+  actorEmail?: string | null
+): Promise<RunDeadlinesResult> {
+  const actor = actorEmail ? `admin:${actorEmail}` : DEFAULT_ACTOR;
+  const { data, error } = await supabase.rpc('admin_run_maintenance_and_log', {
+    p_actor: actor
+  });
+  if (error) throw new Error(error.message);
+  const raw = ensureArray<MaintenanceLogEntry>(data);
+  const challengesProcessed = raw.reduce(
+    (acc, entry) => acc + extractCount(entry, CHALLENGE_KEYS),
+    0
+  );
+  const inactivityProcessed = raw.reduce(
+    (acc, entry) => acc + extractCount(entry, INACTIVITY_KEYS),
+    0
+  );
+  return {
+    challengesProcessed,
+    inactivityProcessed,
+    raw
+  };
+}

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -6,7 +6,7 @@
   import Banner from '$lib/components/Banner.svelte';
   import Loader from '$lib/components/Loader.svelte';
   import { formatSupabaseError, err as errText } from '$lib/ui/alerts';
-  import { runDeadlines } from '$lib/deadlinesService';
+  import { runDeadlines, type RunDeadlinesResult } from '$lib/deadlinesService';
   import { authFetch } from '$lib/utils/http';
 
   let loading = true;
@@ -35,7 +35,7 @@
   let captureErr: string | null = null;
 
   let deadlinesBusy = false;
-  let deadlinesRes: { caducats_sense_acceptar: number; anullats_sense_jugar: number } | null = null;
+  let deadlinesRes: RunDeadlinesResult | null = null;
   let deadlinesErr: string | null = null;
 
   type Change = {
@@ -143,7 +143,7 @@
       deadlinesErr = null;
       deadlinesRes = null;
       const { supabase } = await import('$lib/supabaseClient');
-      const res = await runDeadlines(supabase);
+      const res = await runDeadlines(supabase, $user?.email ?? null);
       deadlinesRes = res;
       await Promise.all([invalidate('/reptes'), invalidate('/admin/reptes')]);
     } catch (e) {
@@ -374,7 +374,16 @@
     <div class="rounded-2xl border p-4">
       <h2 class="font-semibold">⏰ Terminis reptes</h2>
       {#if deadlinesRes}
-        <pre class="text-sm mt-2">{JSON.stringify(deadlinesRes)}</pre>
+        <div class="mt-2 space-y-1 text-sm">
+          <p>Reptes processats: <strong>{deadlinesRes.challengesProcessed}</strong></p>
+          <p>Inactivitats processades: <strong>{deadlinesRes.inactivityProcessed}</strong></p>
+          {#if deadlinesRes.raw.length > 0}
+            <details class="text-xs">
+              <summary class="cursor-pointer text-slate-600">Detall complet</summary>
+              <pre class="mt-1 max-h-48 overflow-auto rounded-xl bg-slate-100 p-2">{JSON.stringify(deadlinesRes.raw, null, 2)}</pre>
+            </details>
+          {/if}
+        </div>
       {/if}
       {#if deadlinesErr}
         <Banner type="error" message={deadlinesErr} class="mb-2" />

--- a/tests/deadlinesService.test.ts
+++ b/tests/deadlinesService.test.ts
@@ -2,12 +2,19 @@ import { describe, it, expect, vi } from 'vitest';
 import { runDeadlines } from '../src/lib/deadlinesService';
 
 describe('deadlinesService', () => {
-  it('calls RPC and returns result', async () => {
-    const rpc = vi.fn().mockResolvedValue({ data: { ok: true, caducats_sense_acceptar: 1, anullats_sense_jugar: 2 }, error: null });
+  it('calls maintenance RPC and returns friendly result', async () => {
+    const payload = [{ challenges_processed: 2, inactivity_processed: 1 }];
+    const rpc = vi.fn().mockResolvedValue({ data: payload, error: null });
     const client = { rpc } as any;
-    const res = await runDeadlines(client);
-    expect(rpc).toHaveBeenCalledWith('run_challenge_deadlines');
-    expect(res).toEqual({ ok: true, caducats_sense_acceptar: 1, anullats_sense_jugar: 2 });
+    const res = await runDeadlines(client, 'admin@example.com');
+    expect(rpc).toHaveBeenCalledWith('admin_run_maintenance_and_log', {
+      p_actor: 'admin:admin@example.com'
+    });
+    expect(res).toEqual({
+      challengesProcessed: 2,
+      inactivityProcessed: 1,
+      raw: payload
+    });
   });
 
   it('throws on error', async () => {
@@ -16,4 +23,3 @@ describe('deadlinesService', () => {
     await expect(runDeadlines(client)).rejects.toThrow('boom');
   });
 });
-


### PR DESCRIPTION
## Summary
- replace the deadlines service to use the new `admin_run_maintenance_and_log` RPC and normalise its response for the UI
- expose a helper for the overdue sweep RPC and allow passing the admin email when running maintenance
- update the admin page summary panel and associated unit test for the new maintenance payload

## Testing
- pnpm test *(fails: @sveltejs/vite-plugin-svelte crashes during Vitest server setup with “TypeError: Cannot convert undefined or null to object”)*

------
https://chatgpt.com/codex/tasks/task_e_68c87930d2d4832e95777521921d9ed0