### PR TITLE
feat: centralize challenge state labels in UI

### DIFF
--- a/src/lib/ui/challengeState.ts
+++ b/src/lib/ui/challengeState.ts
@@ -1,0 +1,8 @@
+export const CHALLENGE_STATE_LABEL: Record<string, string> = {
+  proposat: 'Proposat',
+  acceptat: 'Acceptat',
+  programat: 'Programat',
+  jugat: 'Jugat',
+  anullat: 'Anul·lat',
+  caducat: 'Caducat'
+};

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,6 +4,7 @@
     import { user, status } from '$lib/stores/auth';
     import { getSettings, type AppSettings } from '$lib/settings';
     import { get } from 'svelte/store';
+    import { CHALLENGE_STATE_LABEL } from '$lib/ui/challengeState';
 
   type Challenge = {
     id: string;
@@ -23,6 +24,8 @@
   let recent: Challenge[] = [];
   let warnings: string[] = [];
   let settings: AppSettings;
+
+  const challengeStateLabel = (state: string): string => CHALLENGE_STATE_LABEL[state] ?? state;
 
   onMount(() => {
       const unsub = status.subscribe(async (s) => {
@@ -135,7 +138,7 @@
         {#each active as r}
           <li class="p-3 border rounded">
             <div class="font-medium">{r.reptador_nom} vs {r.reptat_nom}</div>
-            <div class="text-sm text-slate-600">{r.estat}</div>
+            <div class="text-sm text-slate-600">{challengeStateLabel(r.estat)}</div>
           </li>
         {/each}
       </ul>
@@ -152,7 +155,7 @@
           <li class="p-3 border rounded">
             <div class="font-medium">{r.reptador_nom} vs {r.reptat_nom}</div>
             <div class="text-sm text-slate-600">
-              Proposat {new Date(r.data_proposta).toLocaleDateString()}
+              {CHALLENGE_STATE_LABEL.proposat} {new Date(r.data_proposta).toLocaleDateString()}
             </div>
           </li>
         {/each}

--- a/src/routes/admin/reptes/+page.svelte
+++ b/src/routes/admin/reptes/+page.svelte
@@ -7,6 +7,7 @@
         import Loader from '$lib/components/Loader.svelte';
       import { formatSupabaseError, ok as okText, err as errText } from '$lib/ui/alerts';
       import { getSettings, type AppSettings } from '$lib/settings';
+      import { CHALLENGE_STATE_LABEL } from '$lib/ui/challengeState';
 
 
 
@@ -35,6 +36,9 @@
   let isAdmin = false;
   let settings: AppSettings | null = null;
   let reproLimit = 3;
+
+  const challengeStateLabel = (state: string): string =>
+    CHALLENGE_STATE_LABEL[state] ?? state.replace('_', ' ');
 
   
   onMount(load);
@@ -254,7 +258,7 @@
             <td class="px-3 py-2">#{r.pos_reptador ?? '—'} — {r.reptador_nom}</td>
             <td class="px-3 py-2">#{r.pos_reptat ?? '—'} — {r.reptat_nom}</td>
             <td class="px-3 py-2">
-              <span class={`text-xs rounded px-2 py-0.5 capitalize ${estatClass(r.estat)}`}>{r.estat.replace('_',' ')}</span>
+              <span class={`text-xs rounded px-2 py-0.5 ${estatClass(r.estat)}`}>{challengeStateLabel(r.estat)}</span>
             </td>
             <td class="px-3 py-2">{r.reprogram_count} / {reproLimit}</td>
             <td class="px-3 py-2">

--- a/src/routes/admin/reptes/[id]/programar/+page.svelte
+++ b/src/routes/admin/reptes/[id]/programar/+page.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
       import { onMount } from 'svelte';
-        import { page } from '$app/stores';
-        import { user } from '$lib/stores/auth';
-        import { checkIsAdmin } from '$lib/roles';
+    import { page } from '$app/stores';
+    import { user } from '$lib/stores/auth';
+    import { checkIsAdmin } from '$lib/roles';
     import Banner from '$lib/components/Banner.svelte';
     import { formatSupabaseError, ok as okText, err as errText } from '$lib/ui/alerts';
+    import { CHALLENGE_STATE_LABEL } from '$lib/ui/challengeState';
 
   type Challenge = {
     id: string;
@@ -28,6 +29,9 @@
   let data_local = '';
 
   const id = $page.params.id;
+
+  const challengeStateLabel = (state: string): string =>
+    CHALLENGE_STATE_LABEL[state] ?? state.replace('_', ' ');
 
   onMount(load);
 
@@ -165,7 +169,7 @@
     <div class="mb-4 space-y-1">
       <div>Reptador: #{chal.pos_reptador ?? '—'} — {reptadorNom}</div>
       <div>Reptat: #{chal.pos_reptat ?? '—'} — {reptatNom}</div>
-      <div>Estat actual: <span class="capitalize">{chal.estat.replace('_', ' ')}</span></div>
+    <div>Estat actual: <span>{challengeStateLabel(chal.estat)}</span></div>
       <div>Data programada actual: {fmt(chal.data_programada)}</div>
     </div>
 
@@ -190,7 +194,7 @@
         </div>
       </form>
     {:else if frozen}
-      <p class="text-slate-500">El repte està en estat «{chal.estat}» i no es pot programar.</p>
+      <p class="text-slate-500">El repte està en estat «{challengeStateLabel(chal.estat)}» i no es pot programar.</p>
     {/if}
   {/if}
 

--- a/src/routes/admin/reptes/[id]/resultat/+page.svelte
+++ b/src/routes/admin/reptes/[id]/resultat/+page.svelte
@@ -5,6 +5,7 @@
     import { checkIsAdmin } from '$lib/roles';
   import { getSettings, type AppSettings } from '$lib/settings';
   import { refreshRanking } from '$lib/rankingStore';
+  import { CHALLENGE_STATE_LABEL } from '$lib/ui/challengeState';
 
   type Challenge = {
     id: string;
@@ -224,7 +225,7 @@
         if (r?.swapped) rpcMsg = 'Rànquing actualitzat: intercanvi de posicions fet.';
         else rpcMsg = `Rànquing sense canvis${r?.reason ? ' (' + r.reason + ')' : ''}.`;
       }
-      okMsg = 'Resultat desat correctament. Repte marcat com a "jugat".';
+      okMsg = `Resultat desat correctament. Repte marcat com a "${CHALLENGE_STATE_LABEL.jugat.toLowerCase()}".`;
       await refreshRanking();
     } catch (e:any) {
       error = e?.message ?? 'No s’ha pogut desar el resultat';

--- a/src/routes/admin/reptes/nou/+page.svelte
+++ b/src/routes/admin/reptes/nou/+page.svelte
@@ -7,6 +7,7 @@ import Banner from '$lib/components/Banner.svelte';
 import { formatSupabaseError, ok as okText, err as errText } from '$lib/ui/alerts';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { canCreateAccessChallenge } from '$lib/canCreateAccessChallenge';
+import { CHALLENGE_STATE_LABEL } from '$lib/ui/challengeState';
 
   // Configurable al gust: quins estats considerem “actius”
   const ACTIVE_STATES = ['proposat', 'acceptat', 'programat'] as const;
@@ -323,12 +324,12 @@ async function hasActiveChallenge(supabase: SupabaseClient, playerId: string) {
         <div>
           <label for="estat" class="block text-sm mb-1">Estat inicial</label>
           <select id="estat" class="w-full rounded border px-3 py-2" bind:value={estat}>
-            <option value="proposat">Proposat</option>
-            <option value="acceptat">Acceptat (programat)</option>
+            <option value="proposat">{CHALLENGE_STATE_LABEL.proposat}</option>
+            <option value="acceptat">{CHALLENGE_STATE_LABEL.acceptat} ({CHALLENGE_STATE_LABEL.programat.toLowerCase()})</option>
             <option value="refusat">Refusat</option>
-            <option value="caducat">Caducat</option>
-            <option value="jugat">Jugat</option>
-            <option value="anullat">Anullat</option>
+            <option value="caducat">{CHALLENGE_STATE_LABEL.caducat}</option>
+            <option value="jugat">{CHALLENGE_STATE_LABEL.jugat}</option>
+            <option value="anullat">{CHALLENGE_STATE_LABEL.anullat}</option>
           </select>
         </div>
 
@@ -336,13 +337,16 @@ async function hasActiveChallenge(supabase: SupabaseClient, playerId: string) {
           <div>
             <label for="prog" class="block text-sm mb-1">Data programada (opcional)</label>
             <input id="prog" type="datetime-local" class="w-full rounded border px-2 py-1" bind:value={data_programada} />
-            <p class="text-xs text-slate-500 mt-1">Si s’omple, l’estat passa a «programat» i es desa com a <em>data_programada</em>.</p>
+            <p class="text-xs text-slate-500 mt-1">
+              Si s’omple, l’estat passa a «{CHALLENGE_STATE_LABEL.programat.toLowerCase()}» i es desa com a
+              <em>data_programada</em>.
+            </p>
           </div>
         {/if}
       </div>
 
       <fieldset class="border rounded p-3">
-        <legend class="text-sm px-1">Dates proposades (normativa: 3 si “proposat”)</legend>
+        <legend class="text-sm px-1">Dates proposades (normativa: 3 si “{CHALLENGE_STATE_LABEL.proposat.toLowerCase()}”)</legend>
         <div class="grid sm:grid-cols-3 gap-2">
           <div>
             <label for="d1" class="block text-sm mb-1">Data 1</label>

--- a/src/routes/historial/+page.svelte
+++ b/src/routes/historial/+page.svelte
@@ -4,6 +4,7 @@
   import Banner from '$lib/components/Banner.svelte';
   import { supabase } from '$lib/supabaseClient';
   import { formatSupabaseError } from '$lib/ui/alerts';
+  import { CHALLENGE_STATE_LABEL } from '$lib/ui/challengeState';
 
   type Change = {
     creat_el: string;
@@ -46,6 +47,8 @@
   let hasMore = false;
   let lastDate: string | null = null;
   let eventId: string | null = null;
+
+  const challengeStateLabel = (state: string): string => CHALLENGE_STATE_LABEL[state] ?? state;
 
   async function fetchEvent(): Promise<void> {
     const { data, error } = await supabase
@@ -282,13 +285,13 @@
       </select>
       <select class="rounded-xl border px-3 py-2" bind:value={filterEstat}>
         <option value="">Tots els estats</option>
-        <option value="proposat">proposat</option>
-        <option value="acceptat">acceptat</option>
-        <option value="programat">programat</option>
+        <option value="proposat">{CHALLENGE_STATE_LABEL.proposat}</option>
+        <option value="acceptat">{CHALLENGE_STATE_LABEL.acceptat}</option>
+        <option value="programat">{CHALLENGE_STATE_LABEL.programat}</option>
         <option value="refusat">refusat</option>
-        <option value="caducat">caducat</option>
-        <option value="jugat">jugat</option>
-        <option value="anullat">anullat</option>
+        <option value="caducat">{CHALLENGE_STATE_LABEL.caducat}</option>
+        <option value="jugat">{CHALLENGE_STATE_LABEL.jugat}</option>
+        <option value="anullat">{CHALLENGE_STATE_LABEL.anullat}</option>
       </select>
       <button
         class="rounded-xl bg-slate-200 px-3 py-2 text-sm"
@@ -316,7 +319,7 @@
               <td class="p-2 whitespace-nowrap">{new Date(c.data_proposta).toLocaleString()}</td>
               <td class="p-2">{players[c.reptador_id] ?? c.reptador_id}</td>
               <td class="p-2">{players[c.reptat_id] ?? c.reptat_id}</td>
-              <td class="p-2 capitalize">{c.estat}</td>
+              <td class="p-2">{challengeStateLabel(c.estat)}</td>
               <td class="p-2">
                 {#if c.matches && c.matches.length > 0}
                   {c.matches[0].caramboles_reptador} - {c.matches[0].caramboles_reptat}

--- a/src/routes/reptes/+page.svelte
+++ b/src/routes/reptes/+page.svelte
@@ -4,6 +4,7 @@
     import type { SupabaseClient } from '@supabase/supabase-js';
     import { acceptChallenge, refuseChallenge, scheduleChallenge } from '$lib/challenges';
     import { getSettings, type AppSettings } from '$lib/settings';
+    import { CHALLENGE_STATE_LABEL } from '$lib/ui/challengeState';
 
 
   type Challenge = {
@@ -43,6 +44,7 @@
     const d = new Date(local);
     return isNaN(d.getTime()) ? null : d.toISOString();
   };
+  const challengeStateLabel = (state: string): string => CHALLENGE_STATE_LABEL[state] ?? state;
 
   async function load() {
     try {
@@ -202,14 +204,14 @@
         {#each actius as r}
           <li class="p-3 border rounded">
             <div class="font-medium">{r.reptador_nom} vs {r.reptat_nom}</div>
-            <div class="text-sm text-slate-600 capitalize">Estat: {r.estat}</div>
+            <div class="text-sm text-slate-600">Estat: {challengeStateLabel(r.estat)}</div>
             <div class="text-sm text-slate-600">
-              Proposat: {fmtDate(r.data_proposta)}
+              {CHALLENGE_STATE_LABEL.proposat}: {fmtDate(r.data_proposta)}
               {#if r.data_acceptacio}
-                • Acceptat: {fmtDate(r.data_acceptacio)}
+                • {CHALLENGE_STATE_LABEL.acceptat}: {fmtDate(r.data_acceptacio)}
               {/if}
               {#if r.data_programada}
-                • Programat: {fmtDate(r.data_programada)}
+                • {CHALLENGE_STATE_LABEL.programat}: {fmtDate(r.data_programada)}
               {/if}
             </div>
             <div class="text-sm text-slate-600">Reprogramacions: {r.reprogramacions ?? 0} / {reproLimit}</div>

--- a/src/routes/reptes/[id]/resultat/+page.svelte
+++ b/src/routes/reptes/[id]/resultat/+page.svelte
@@ -7,6 +7,7 @@
     import { formatSupabaseError, ok as okText, err as errText } from '$lib/ui/alerts';
     import { refreshRanking } from '$lib/rankingStore';
     import { addToast } from '$lib/ui/toastStore';
+    import { CHALLENGE_STATE_LABEL } from '$lib/ui/challengeState';
 
   type Challenge = {
     id: string;
@@ -204,7 +205,9 @@
         addToast('Rànquing actualitzat', 'success');
       }
 
-      okMsg = okText('Resultat desat correctament. Repte marcat com a jugat.');
+      okMsg = okText(
+        `Resultat desat correctament. Repte marcat com a ${CHALLENGE_STATE_LABEL.jugat.toLowerCase()}.`
+      );
     } catch (e) {
       error = formatSupabaseError(e);
     } finally {

--- a/src/routes/reptes/me/+page.svelte
+++ b/src/routes/reptes/me/+page.svelte
@@ -4,6 +4,7 @@
 
 import { getSettings, type AppSettings } from '$lib/settings';
 import { checkIsAdmin } from '$lib/roles';
+import { CHALLENGE_STATE_LABEL } from '$lib/ui/challengeState';
 
 
 type Challenge = {
@@ -39,6 +40,12 @@ export let data: { settings: AppSettings };
 let settings: AppSettings = data.settings;
 let isAdmin = false;
 let reproLimit = settings.reprogramacions_limit ?? 3;
+
+const challengeStateLabel = (state: string): string => CHALLENGE_STATE_LABEL[state] ?? state;
+const challengeStatePluralLabel = (state: string): string => {
+  const label = challengeStateLabel(state);
+  return label.endsWith('s') ? label : `${label}s`;
+};
 
 onMount(async () => {
   isAdmin = await checkIsAdmin();
@@ -355,13 +362,13 @@ async function saveSchedule(r: Challenge) {
       class={`pb-1 border-b-2 ${tab === 'programats' ? 'border-slate-800 font-semibold' : 'border-transparent text-slate-500'}`}
       on:click={() => (tab = 'programats')}
     >
-      Programats ({programats.length})
+      {challengeStatePluralLabel('programat')} ({programats.length})
     </button>
     <button
       class={`pb-1 border-b-2 ${tab === 'jugats' ? 'border-slate-800 font-semibold' : 'border-transparent text-slate-500'}`}
       on:click={() => (tab = 'jugats')}
     >
-      Jugats ({jugats.length})
+      {challengeStatePluralLabel('jugat')} ({jugats.length})
     </button>
   </div>
 
@@ -375,10 +382,10 @@ async function saveSchedule(r: Challenge) {
         <div class="rounded border p-3 space-y-2">
           <div class="flex flex-wrap items-center gap-2">
             <span class="text-xs rounded bg-slate-800 text-white px-2 py-0.5">{r.tipus}</span>
-            <span class="text-xs rounded bg-slate-100 px-2 py-0.5 capitalize">{r.estat}</span>
-            <span class="text-xs text-slate-500 ml-auto">Proposat: {fmt(r.data_proposta)}</span>
+            <span class="text-xs rounded bg-slate-100 px-2 py-0.5">{challengeStateLabel(r.estat)}</span>
+            <span class="text-xs text-slate-500 ml-auto">{CHALLENGE_STATE_LABEL.proposat}: {fmt(r.data_proposta)}</span>
             {#if r.data_programada}
-              <span class="text-xs text-slate-500">Programat: {fmt(r.data_programada)}</span>
+              <span class="text-xs text-slate-500">{CHALLENGE_STATE_LABEL.programat}: {fmt(r.data_programada)}</span>
             {/if}
           </div>
 


### PR DESCRIPTION
## Summary
- add a shared `CHALLENGE_STATE_LABEL` map for consistent challenge status labels
- update ranking history filters, player dashboards, and public challenge lists to read labels from the shared map
- align admin challenge forms, tables, and success messages with the centralized labels, including replacing inline text

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68c879d95004832ea852d64e15b622ff