### PR TITLE
Update admin settings with inactivity fields

### DIFF
--- a/src/lib/components/PropostaDataForm.svelte
+++ b/src/lib/components/PropostaDataForm.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
   import { supabase } from '$lib/supabaseClient';
   import Banner from '$lib/components/Banner.svelte';
-  import { onMount } from 'svelte';
-  import { getSettings, type AppSettings } from '$lib/settings';
-
+  import { isParticipant } from '$lib/challenges';
   import { authFetch } from '$lib/utils/http';
 
 
@@ -16,13 +14,8 @@
   let submitting = false;
   let err: string | null = null;
   let ok: string | null = null;
-  let settings: AppSettings | null = null;
-  let limit = 3;
-
-  onMount(async () => {
-    settings = await getSettings();
-    limit = settings?.reprogramacions_limit ?? 3;
-  });
+  const REPROGRAM_LIMIT = 3;
+  let limit = REPROGRAM_LIMIT;
 
   async function ensureChallengeParties() {
     // Si no han arribat per props, els busquem

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -7,7 +7,8 @@ export type AppSettings = {
   dies_acceptar_repte: number;
   dies_jugar_despres_acceptar: number;
   ranking_max_jugadors: number;
-  reprogramacions_limit: number;
+  pre_inactiu_setmanes: number;
+  inactiu_setmanes: number;
   updated_at?: string;
   id?: string;
 };
@@ -21,7 +22,8 @@ const DEFAULT_SETTINGS: AppSettings = {
   dies_acceptar_repte: 7,
   dies_jugar_despres_acceptar: 7,
   ranking_max_jugadors: 20,
-  reprogramacions_limit: 3
+  pre_inactiu_setmanes: 3,
+  inactiu_setmanes: 6
 };
 
 let cache: AppSettings | null = null;
@@ -37,14 +39,45 @@ export async function getSettings(): Promise<AppSettings> {
       .limit(1)
       .maybeSingle();
     if (error) throw error;
-    cache = data ?? DEFAULT_SETTINGS;
+    cache = data
+      ? {
+          ...DEFAULT_SETTINGS,
+          ...data,
+          pre_inactiu_setmanes: data.pre_inactiu_setmanes ?? DEFAULT_SETTINGS.pre_inactiu_setmanes,
+          inactiu_setmanes: data.inactiu_setmanes ?? DEFAULT_SETTINGS.inactiu_setmanes
+        }
+      : DEFAULT_SETTINGS;
   } catch {
     cache = DEFAULT_SETTINGS;
   }
-    return cache as AppSettings;
+  return cache as AppSettings;
 }
 
 export function invalidate() {
   cache = null;
+}
+
+export type UpdateSettingsInput = {
+  diesAcceptar: number;
+  diesJugar: number;
+  preInact: number;
+  inact: number;
+};
+
+export async function updateSettingsValues({
+  diesAcceptar,
+  diesJugar,
+  preInact,
+  inact
+}: UpdateSettingsInput): Promise<void> {
+  const { supabase } = await import('$lib/supabaseClient');
+  const { error } = await supabase.rpc('admin_update_settings', {
+    p_dies_acceptar: diesAcceptar,
+    p_dies_jugar: diesJugar,
+    p_pre_inact: preInact,
+    p_inact: inact
+  });
+  if (error) throw error;
+  invalidate();
 }
 

--- a/src/routes/admin/config/+page.svelte
+++ b/src/routes/admin/config/+page.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-    import { onMount } from 'svelte';
-      import { user } from '$lib/stores/auth';
-    import { checkIsAdmin } from '$lib/roles';
-    import Banner from '$lib/components/Banner.svelte';
-    import Loader from '$lib/components/Loader.svelte';
-    import { formatSupabaseError, ok as okText, err as errText } from '$lib/ui/alerts';
-
+  import { onMount } from 'svelte';
+  import { user } from '$lib/stores/auth';
+  import { checkIsAdmin } from '$lib/roles';
+  import Banner from '$lib/components/Banner.svelte';
+  import Loader from '$lib/components/Loader.svelte';
+  import { formatSupabaseError, ok as okText, err as errText } from '$lib/ui/alerts';
+  import { updateSettingsValues } from '$lib/settings';
 
   type Settings = {
     id?: string;
@@ -17,7 +17,22 @@
     dies_acceptar_repte: number;
     dies_jugar_despres_acceptar: number;
     ranking_max_jugadors: number;
+    pre_inactiu_setmanes: number;
+    inactiu_setmanes: number;
     updated_at?: string | null;
+  };
+
+  const DEFAULT_FORM: Settings = {
+    caramboles_objectiu: 20,
+    max_entrades: 50,
+    allow_tiebreak: true,
+    cooldown_min_dies: 3,
+    cooldown_max_dies: 7,
+    dies_acceptar_repte: 7,
+    dies_jugar_despres_acceptar: 7,
+    ranking_max_jugadors: 20,
+    pre_inactiu_setmanes: 3,
+    inactiu_setmanes: 6
   };
 
   let form: Settings | null = null;
@@ -33,25 +48,33 @@
     const { data } = await supabase
       .from('app_settings')
       .select(
-        'id,caramboles_objectiu,max_entrades,allow_tiebreak,cooldown_min_dies,cooldown_max_dies,dies_acceptar_repte,dies_jugar_despres_acceptar,ranking_max_jugadors,updated_at'
+        'id,caramboles_objectiu,max_entrades,allow_tiebreak,cooldown_min_dies,cooldown_max_dies,dies_acceptar_repte,dies_jugar_despres_acceptar,ranking_max_jugadors,pre_inactiu_setmanes,inactiu_setmanes,updated_at'
       )
       .order('updated_at', { ascending: false })
       .limit(1)
       .maybeSingle();
 
     if (data) {
-      form = data as Settings;
-    } else {
+      const partial = data as Partial<Settings>;
       form = {
-        caramboles_objectiu: 20,
-        max_entrades: 50,
-        allow_tiebreak: true,
-        cooldown_min_dies: 3,
-        cooldown_max_dies: 7,
-        dies_acceptar_repte: 7,
-        dies_jugar_despres_acceptar: 7,
-        ranking_max_jugadors: 20
+        ...DEFAULT_FORM,
+        ...partial,
+        caramboles_objectiu: partial.caramboles_objectiu ?? DEFAULT_FORM.caramboles_objectiu,
+        max_entrades: partial.max_entrades ?? DEFAULT_FORM.max_entrades,
+        allow_tiebreak: partial.allow_tiebreak ?? DEFAULT_FORM.allow_tiebreak,
+        cooldown_min_dies: partial.cooldown_min_dies ?? DEFAULT_FORM.cooldown_min_dies,
+        cooldown_max_dies: partial.cooldown_max_dies ?? DEFAULT_FORM.cooldown_max_dies,
+        dies_acceptar_repte: partial.dies_acceptar_repte ?? DEFAULT_FORM.dies_acceptar_repte,
+        dies_jugar_despres_acceptar:
+          partial.dies_jugar_despres_acceptar ?? DEFAULT_FORM.dies_jugar_despres_acceptar,
+        ranking_max_jugadors: partial.ranking_max_jugadors ?? DEFAULT_FORM.ranking_max_jugadors,
+        pre_inactiu_setmanes: partial.pre_inactiu_setmanes ?? DEFAULT_FORM.pre_inactiu_setmanes,
+        inactiu_setmanes: partial.inactiu_setmanes ?? DEFAULT_FORM.inactiu_setmanes,
+        updated_at: partial.updated_at ?? null,
+        id: partial.id
       };
+    } else {
+      form = { ...DEFAULT_FORM };
     }
   }
 
@@ -92,6 +115,12 @@
       return 'Dies per jugar després d’acceptar han de ser un enter > 0';
     if (!Number.isInteger(form.ranking_max_jugadors) || form.ranking_max_jugadors <= 0)
       return 'Rànquing: màxim jugadors ha de ser un enter > 0';
+    if (!Number.isInteger(form.pre_inactiu_setmanes) || form.pre_inactiu_setmanes < 0)
+      return 'Pre-inactivitat ha de ser un enter ≥ 0';
+    if (!Number.isInteger(form.inactiu_setmanes) || form.inactiu_setmanes <= 0)
+      return 'Inactivitat ha de ser un enter > 0';
+    if (form.pre_inactiu_setmanes >= form.inactiu_setmanes)
+      return 'La pre-inactivitat ha de ser inferior a la inactivitat';
     return null;
   }
 
@@ -128,13 +157,23 @@
             cooldown_max_dies: form.cooldown_max_dies,
             dies_acceptar_repte: form.dies_acceptar_repte,
             dies_jugar_despres_acceptar: form.dies_jugar_despres_acceptar,
-            ranking_max_jugadors: form.ranking_max_jugadors
+            ranking_max_jugadors: form.ranking_max_jugadors,
+            pre_inactiu_setmanes: form.pre_inactiu_setmanes,
+            inactiu_setmanes: form.inactiu_setmanes
           })
           .select('id')
           .single();
         if (e) throw e;
+        if (!inserted?.id) throw new Error('No s’ha pogut crear la configuració');
         form.id = inserted.id;
       }
+
+      await updateSettingsValues({
+        diesAcceptar: form.dies_acceptar_repte,
+        diesJugar: form.dies_jugar_despres_acceptar,
+        preInact: form.pre_inactiu_setmanes,
+        inact: form.inactiu_setmanes
+      });
       await loadSettings();
       ok = okText('Configuració desada');
     } catch (e) {
@@ -245,6 +284,29 @@
               class="w-full rounded-xl border px-3 py-2"
               bind:value={form.dies_jugar_despres_acceptar}
             />
+          </div>
+
+          <div class="flex gap-4">
+            <div class="flex-1">
+              <label for="pre_inactiu_setmanes" class="block text-sm mb-1">Pre-inactivitat (setmanes)</label>
+              <input
+                id="pre_inactiu_setmanes"
+                type="number"
+                min="0"
+                class="w-full rounded-xl border px-3 py-2"
+                bind:value={form.pre_inactiu_setmanes}
+              />
+            </div>
+            <div class="flex-1">
+              <label for="inactiu_setmanes" class="block text-sm mb-1">Inactivitat (setmanes)</label>
+              <input
+                id="inactiu_setmanes"
+                type="number"
+                min="1"
+                class="w-full rounded-xl border px-3 py-2"
+                bind:value={form.inactiu_setmanes}
+              />
+            </div>
           </div>
 
           <div>

--- a/src/routes/admin/config/+page.ts
+++ b/src/routes/admin/config/+page.ts
@@ -8,7 +8,7 @@ export const load: PageLoad = async () => {
   const { data, error } = await supabase
     .from('app_settings')
     .select(
-      'id, caramboles_objectiu, max_entrades, allow_tiebreak, cooldown_min_dies, cooldown_max_dies, dies_acceptar_repte, dies_jugar_despres_acceptar, ranking_max_jugadors'
+      'id, caramboles_objectiu, max_entrades, allow_tiebreak, cooldown_min_dies, cooldown_max_dies, dies_acceptar_repte, dies_jugar_despres_acceptar, ranking_max_jugadors, pre_inactiu_setmanes, inactiu_setmanes, updated_at'
     )
     .order('updated_at', { ascending: false })
     .limit(1)

--- a/src/routes/admin/reptes/+page.svelte
+++ b/src/routes/admin/reptes/+page.svelte
@@ -2,11 +2,11 @@
 
         import { onMount } from 'svelte';
         import { user } from '$lib/stores/auth';
-        import { checkIsAdmin } from '$lib/roles';
-        import Banner from '$lib/components/Banner.svelte';
-        import Loader from '$lib/components/Loader.svelte';
+      import { checkIsAdmin } from '$lib/roles';
+      import Banner from '$lib/components/Banner.svelte';
+      import Loader from '$lib/components/Loader.svelte';
       import { formatSupabaseError, ok as okText, err as errText } from '$lib/ui/alerts';
-      import { getSettings, type AppSettings } from '$lib/settings';
+      import { authFetch } from '$lib/utils/http';
       import { CHALLENGE_STATE_LABEL } from '$lib/ui/challengeState';
 
 
@@ -34,8 +34,8 @@
   let rows: ChallengeRow[] = [];
   let busy: string | null = null; // id en acció
   let isAdmin = false;
-  let settings: AppSettings | null = null;
-  let reproLimit = 3;
+  const REPRO_LIMIT = 3;
+  let reproLimit = REPRO_LIMIT;
 
   const challengeStateLabel = (state: string): string =>
     CHALLENGE_STATE_LABEL[state] ?? state.replace('_', ' ');
@@ -71,8 +71,6 @@
         isAdmin = true;
 
       const { supabase } = await import('$lib/supabaseClient');
-      settings = await getSettings();
-      reproLimit = settings?.reprogramacions_limit ?? 3;
 
       const { data: ch, error: e1 } = await supabase
         .from('challenges')

--- a/src/routes/reptes/+page.svelte
+++ b/src/routes/reptes/+page.svelte
@@ -3,7 +3,6 @@
     import { user } from '$lib/stores/auth';
     import type { SupabaseClient } from '@supabase/supabase-js';
     import { acceptChallenge, refuseChallenge, scheduleChallenge } from '$lib/challenges';
-    import { getSettings, type AppSettings } from '$lib/settings';
     import { CHALLENGE_STATE_LABEL } from '$lib/ui/challengeState';
 
 
@@ -36,8 +35,8 @@
   let myPlayerId: string | null = null;
   let supabase: SupabaseClient;
   let dateDrafts: Record<string, string> = {};
-  let settings: AppSettings | null = null;
-  let reproLimit = 3;
+  const REPRO_LIMIT = 3;
+  let reproLimit = REPRO_LIMIT;
 
   const fmtDate = (iso: string | null) => (iso ? new Date(iso).toLocaleString() : '—');
   const parseLocalToIso = (local: string) => {
@@ -51,9 +50,6 @@
       loading = true;
       const mod = await import('$lib/supabaseClient');
       supabase = mod.supabase;
-
-      settings = await getSettings();
-      reproLimit = settings?.reprogramacions_limit ?? 3;
 
       const { data: auth } = await supabase.auth.getUser();
       if (auth?.user?.email) {

--- a/src/routes/reptes/me/+page.svelte
+++ b/src/routes/reptes/me/+page.svelte
@@ -5,6 +5,7 @@
 import { getSettings, type AppSettings } from '$lib/settings';
 import { checkIsAdmin } from '$lib/roles';
 import { CHALLENGE_STATE_LABEL } from '$lib/ui/challengeState';
+import { authFetch } from '$lib/utils/http';
 
 
 type Challenge = {
@@ -39,7 +40,8 @@ let current: Challenge[] = [];
 export let data: { settings: AppSettings };
 let settings: AppSettings = data.settings;
 let isAdmin = false;
-let reproLimit = settings.reprogramacions_limit ?? 3;
+const REPRO_LIMIT = 3;
+let reproLimit = REPRO_LIMIT;
 
 const challengeStateLabel = (state: string): string => CHALLENGE_STATE_LABEL[state] ?? state;
 const challengeStatePluralLabel = (state: string): string => {


### PR DESCRIPTION
## Summary
- add inactivity week fields to the app settings type/defaults and expose an RPC helper
- include the new inactivity inputs on the admin config page and call `admin_update_settings`
- remove usage of `reprogramacions_limit` in the UI, keeping a fixed limit constant instead

## Testing
- pnpm check

------
https://chatgpt.com/codex/tasks/task_e_68c87db1ca7c832e8d772b54facd44f4