### PR TITLE
Add Supabase access for player badges

### DIFF
--- a/src/lib/playerBadges.ts
+++ b/src/lib/playerBadges.ts
@@ -1,0 +1,20 @@
+import { supabase } from '$lib/supabaseClient';
+
+export type VPlayerBadges = {
+  event_id: string;
+  player_id: string;
+  posicio: number;
+  last_play_date: string | null;
+  days_since_last: number | null;
+  has_active_challenge: boolean;
+  in_cooldown: boolean;
+  can_be_challenged: boolean;
+};
+
+export async function getPlayerBadges(): Promise<VPlayerBadges[]> {
+  const { data, error } = await supabase
+    .from('v_player_badges')
+    .select('*');
+  if (error) throw error;
+  return (data ?? []) as VPlayerBadges[];
+}

--- a/tests/playerBadges.test.ts
+++ b/tests/playerBadges.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const supabaseMock = vi.hoisted(() => ({
+  from: vi.fn(),
+  select: vi.fn()
+}));
+
+vi.mock('$lib/supabaseClient', () => {
+  const select = vi.fn();
+  const from = vi.fn(() => ({ select }));
+  supabaseMock.from = from;
+  supabaseMock.select = select;
+  return {
+    supabase: { from }
+  };
+});
+
+import { getPlayerBadges } from '../src/lib/playerBadges';
+
+beforeEach(() => {
+  supabaseMock.select.mockReset();
+  supabaseMock.from.mockClear();
+});
+
+describe('getPlayerBadges', () => {
+  it('returns player badges when query succeeds', async () => {
+    const rows = [
+      {
+        event_id: 'event-1',
+        player_id: 'player-1',
+        posicio: 1,
+        last_play_date: '2024-01-01',
+        days_since_last: 3,
+        has_active_challenge: true,
+        in_cooldown: false,
+        can_be_challenged: false
+      }
+    ];
+    supabaseMock.select.mockResolvedValue({ data: rows, error: null });
+
+    const result = await getPlayerBadges();
+
+    expect(supabaseMock.from).toHaveBeenCalledWith('v_player_badges');
+    expect(supabaseMock.select).toHaveBeenCalledWith('*');
+    expect(result).toEqual(rows);
+  });
+
+  it('returns empty array when no rows', async () => {
+    supabaseMock.select.mockResolvedValue({ data: null, error: null });
+
+    const result = await getPlayerBadges();
+
+    expect(result).toEqual([]);
+  });
+
+  it('throws when supabase returns error', async () => {
+    const err = new Error('select failed');
+    supabaseMock.select.mockResolvedValue({ data: null, error: err });
+
+    await expect(getPlayerBadges()).rejects.toBe(err);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,21 @@
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export default defineConfig({
+  test: {
+    environment: 'node'
+  },
+  resolve: {
+    alias: {
+      $lib: resolve(__dirname, './src/lib')
+    }
+  },
+  define: {
+    'import.meta.env.PUBLIC_SUPABASE_URL': JSON.stringify('https://qbldqtaqawnahuzlzsjs.supabase.co'),
+    'import.meta.env.PUBLIC_SUPABASE_ANON_KEY': JSON.stringify('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFibGRxdGFxYXduYWh1emx6c2pzIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTcwNTkyMDgsImV4cCI6MjA3MjYzNTIwOH0.bLMQFuZkIRW3r41P18Y4eipu1nbNUx3_0QtpwyVZqN4')
+  }
+});


### PR DESCRIPTION
## Summary
- add the `VPlayerBadges` model and `getPlayerBadges` helper for the Supabase view
- configure Vitest to resolve `$lib` imports and expose Supabase environment variables during tests
- cover the new helper with unit tests that mock the Supabase client

## Testing
- pnpm test
- pnpm check *(fails: existing svelte-check errors about missing global names)*

------
https://chatgpt.com/codex/tasks/task_e_68c87ec09d88832e93ddca258e4960ef