### PR TITLE
feat: load player badges on classification page

### DIFF
--- a/src/routes/classificacio/+page.server.ts
+++ b/src/routes/classificacio/+page.server.ts
@@ -1,0 +1,15 @@
+import type { PageServerLoad } from './$types';
+import type { VPlayerBadges } from '$lib/server/daoAdmin';
+import { getPlayerBadges } from '$lib/server/daoAdmin';
+
+export const prerender = false;
+
+export const load: PageServerLoad = async () => {
+  try {
+    const badges = await getPlayerBadges();
+    return { badges };
+  } catch (error) {
+    console.error('No s\u2019han pogut carregar els badges dels jugadors', error);
+    return { badges: null as VPlayerBadges[] | null };
+  }
+};

--- a/src/routes/classificacio/+page.ts
+++ b/src/routes/classificacio/+page.ts
@@ -1,2 +1,0 @@
-export const ssr = false;
-export const prerender = false;


### PR DESCRIPTION
## Summary
- expose a server-side helper to gather active challenges and cooldown flags for players
- fetch player badges in the classificacio load function and pass them to the page
- reuse preloaded badge data on the client while keeping the existing fallback logic

## Testing
- pnpm check *(fails: existing missing symbol errors in unrelated files)*
- pnpm test *(fails: Vitest crashes during Vite server setup in this repo)*

------
https://chatgpt.com/codex/tasks/task_e_68c87efda07c832ea82d59d85369d480