### PR TITLE
Add Supabase DAO for player badges

### DIFF
--- a/src/lib/playerBadges.ts
+++ b/src/lib/playerBadges.ts
@@ -1,24 +1,17 @@
 export type VPlayerBadges = {
+  event_id: string;
   player_id: string;
+  posicio: number;
+  last_play_date: string | null;
+  days_since_last: number | null;
   has_active_challenge: boolean;
   in_cooldown: boolean;
   can_be_challenged: boolean;
-  days_since_last: number | null;
 };
 
 export async function getPlayerBadges(): Promise<VPlayerBadges[]> {
-  try {
-    const { supabase } = await import('$lib/supabaseClient');
-    const { data, error } = await supabase
-      .from('v_player_badges')
-      .select('player_id,has_active_challenge,in_cooldown,can_be_challenged,days_since_last');
-    if (error) {
-      console.warn('[playerBadges] v_player_badges error:', error.message);
-      return [];
-    }
-    return (data ?? []) as VPlayerBadges[];
-  } catch (e) {
-    console.warn('[playerBadges] Unexpected error loading badges:', e);
-    return [];
-  }
+  const { supabase } = await import('$lib/supabaseClient');
+  const { data, error } = await supabase.from('v_player_badges').select('*');
+  if (error) throw error;
+  return (data ?? []) as VPlayerBadges[];
 }

--- a/tests/playerBadges.test.ts
+++ b/tests/playerBadges.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { VPlayerBadges } from '../src/lib/playerBadges';
+
+const selectMock = vi.fn();
+const fromMock = vi.fn(() => ({ select: selectMock }));
+
+vi.mock('$lib/supabaseClient', () => ({
+  supabase: {
+    from: fromMock
+  }
+}));
+
+import { getPlayerBadges } from '../src/lib/playerBadges';
+
+describe('getPlayerBadges', () => {
+  beforeEach(() => {
+    selectMock.mockReset();
+    fromMock.mockClear();
+  });
+
+  it('retrieves badge data from supabase', async () => {
+    const sample: VPlayerBadges[] = [
+      {
+        event_id: 'event-1',
+        player_id: 'player-1',
+        posicio: 1,
+        last_play_date: '2024-01-01',
+        days_since_last: 2,
+        has_active_challenge: true,
+        in_cooldown: false,
+        can_be_challenged: false
+      }
+    ];
+    selectMock.mockResolvedValue({ data: sample, error: null });
+
+    const result = await getPlayerBadges();
+
+    expect(fromMock).toHaveBeenCalledWith('v_player_badges');
+    expect(selectMock).toHaveBeenCalledWith('*');
+    expect(result).toEqual(sample);
+  });
+
+  it('throws when supabase returns an error', async () => {
+    const supabaseError = { message: 'boom' } as const;
+    selectMock.mockResolvedValue({ data: null, error: supabaseError });
+
+    await expect(getPlayerBadges()).rejects.toBe(supabaseError);
+  });
+
+  it('returns an empty array when supabase has no rows', async () => {
+    selectMock.mockResolvedValue({ data: null, error: null });
+
+    const result = await getPlayerBadges();
+
+    expect(result).toEqual([]);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,21 @@
+import path from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node'
+  },
+  resolve: {
+    alias: {
+      $lib: path.resolve(__dirname, 'src/lib')
+    }
+  },
+  define: {
+    'import.meta.env.PUBLIC_SUPABASE_URL': JSON.stringify(
+      'https://qbldqtaqawnahuzlzsjs.supabase.co'
+    ),
+    'import.meta.env.PUBLIC_SUPABASE_ANON_KEY': JSON.stringify(
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFibGRxdGFxYXduYWh1emx6c2pzIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTcwNTkyMDgsImV4cCI6MjA3MjYzNTIwOH0.bLMQFuZkIRW3r41P18Y4eipu1nbNUx3_0QtpwyVZqN4'
+    )
+  }
+});


### PR DESCRIPTION
## Summary
- extend the Supabase player badges DAO to expose ranking metadata and return typed arrays
- surface Supabase errors while defaulting to empty arrays when no rows are returned
- add Vitest configuration and unit tests that mock Supabase to cover the new DAO

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68c882489660832e9f3ef6e8c2bb8cd9