### PR TITLE
Point classificacio navigation to home

### DIFF
--- a/src/lib/components/Nav.svelte
+++ b/src/lib/components/Nav.svelte
@@ -7,7 +7,7 @@
   const baseLinks = [
     { href: '/', label: 'Inici' },
     { href: '/calendari', label: 'Calendari' },
-    { href: '/classificacio', label: 'Classificació' },
+    { href: '/', label: 'Classificació' },
     { href: '/reptes', label: 'Reptes' },
     { href: '/llista-espera', label: "Llista d'espera" },
     { href: '/socis', label: 'Socis' }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -70,8 +70,12 @@
 
   // helper d’estils opcionals per remarcar link actiu
   import { page } from "$app/stores";
-  const isActive = (href: string, current: string) =>
-    current.startsWith(href) ? "underline font-semibold" : "hover:underline";
+  const isActive = (href: string, current: string) => {
+    if (href === '/') {
+      return current === '/' ? "underline font-semibold" : "hover:underline";
+    }
+    return current.startsWith(href) ? "underline font-semibold" : "hover:underline";
+  };
 
   let menuOpen = false;
   const toggleMenu = () => (menuOpen = !menuOpen);
@@ -90,7 +94,7 @@
 
     <div class="hidden md:flex items-center gap-6 flex-1">
       <a href="/calendari" class={isActive("/calendari", $page.url.pathname)}>Calendari</a>
-      <a href="/classificacio" class={isActive("/classificacio", $page.url.pathname)}>Classificació</a>
+      <a href="/" class={isActive("/", $page.url.pathname)}>Classificació</a>
       <a href="/reptes" class={isActive("/reptes", $page.url.pathname)}>Reptes</a>
       <a href="/llista-espera" class={isActive("/llista-espera", $page.url.pathname)}>Llista d'espera</a>
       <a href="/historial" class={isActive("/historial", $page.url.pathname)}>Historial</a>
@@ -138,7 +142,7 @@
   {#if menuOpen}
     <div class="md:hidden px-4 pb-4 flex flex-col gap-2">
       <a href="/calendari" class={isActive("/calendari", $page.url.pathname)}>Calendari</a>
-      <a href="/classificacio" class={isActive("/classificacio", $page.url.pathname)}>Classificació</a>
+      <a href="/" class={isActive("/", $page.url.pathname)}>Classificació</a>
       <a href="/reptes" class={isActive("/reptes", $page.url.pathname)}>Reptes</a>
       <a href="/llista-espera" class={isActive("/llista-espera", $page.url.pathname)}>Llista d'espera</a>
       <a href="/historial" class={isActive("/historial", $page.url.pathname)}>Historial</a>

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -191,7 +191,7 @@
       await Promise.all([
         invalidate('/reptes'),
         invalidate('/admin/reptes'),
-        invalidate('/classificacio'),
+        invalidate('/ranking'),
         invalidate('/llista-espera'),
         invalidateAll()
       ]);

--- a/src/routes/classificacio/+page.ts
+++ b/src/routes/classificacio/+page.ts
@@ -1,2 +1,8 @@
+import { redirect } from '@sveltejs/kit';
+
 export const ssr = false;
 export const prerender = false;
+
+export function load() {
+  throw redirect(302, '/');
+}

--- a/src/routes/inscripcio/+page.svelte
+++ b/src/routes/inscripcio/+page.svelte
@@ -109,7 +109,7 @@
         inRanking = true;
       }
       await Promise.all([
-        invalidate('/classificacio'),
+        invalidate('/ranking'),
         invalidate('/llista-espera')
       ]);
     } catch (e: any) {


### PR DESCRIPTION
## Summary
- point the "Classificació" links in both navigation bars to the home page so it matches the initial load
- ensure the shared layout treats the home path as active only on the front page to avoid highlighting it everywhere
- redirect `/classificacio` to `/` so direct visits show the same content as the start view

## Testing
- pnpm check *(fails: duplicate identifier errors already present in PropostaDataForm.svelte and admin/reptes page)*

------
https://chatgpt.com/codex/tasks/task_e_68c88215f8b8832e92de9c6cecbf8414