### PR TITLE
Add accessible player badge component with tests

### DIFF
--- a/src/lib/components/PlayerBadges.svelte
+++ b/src/lib/components/PlayerBadges.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  import { buildBadgeDescriptors } from '$lib/playerBadges';
+  import type { PlayerBadgeDescriptor, PlayerBadgeSource } from '$lib/playerBadges';
+
+  export let row: PlayerBadgeSource;
+
+  const dispatch = createEventDispatcher<{ challenge: string }>();
+
+  let badges: PlayerBadgeDescriptor[] = [];
+  $: badges = buildBadgeDescriptors(row);
+
+  const handleChallenge = () => {
+    if (row.player_id) {
+      dispatch('challenge', row.player_id);
+    }
+  };
+</script>
+
+{#each badges as badge (badge.state)}
+  {#if badge.element === 'button'}
+    <button
+      type="button"
+      class={badge.className}
+      title={badge.title}
+      aria-label={badge.ariaLabel}
+      disabled={badge.disabled ? true : undefined}
+      on:click={handleChallenge}
+    >
+      {badge.text}
+    </button>
+  {:else}
+    <span
+      class={badge.className}
+      title={badge.title}
+      aria-label={badge.ariaLabel}
+    >
+      {badge.text}
+    </span>
+  {/if}
+{/each}

--- a/src/lib/playerBadges.ts
+++ b/src/lib/playerBadges.ts
@@ -1,0 +1,131 @@
+export type PlayerBadgeSource = {
+  player_id: string;
+  isMe?: boolean;
+  hasActiveChallenge?: boolean;
+  cooldownToChallenge?: boolean;
+  reptable?: boolean;
+  canChallenge?: boolean;
+  reason?: string | null;
+  protected?: boolean;
+  outside?: boolean;
+};
+
+export type PlayerBadgeState =
+  | { type: 'self' }
+  | { type: 'active-challenge' }
+  | { type: 'cooldown' }
+  | { type: 'can-challenge' }
+  | { type: 'reptable'; canChallenge: boolean; reason: string | null }
+  | { type: 'protected' }
+  | { type: 'outside' };
+
+export function getPlayerBadges(row: PlayerBadgeSource): PlayerBadgeState[] {
+  const badges: PlayerBadgeState[] = [];
+
+  if (row.isMe) {
+    badges.push({ type: 'self' });
+  }
+
+  if (row.hasActiveChallenge) {
+    badges.push({ type: 'active-challenge' });
+  } else if (row.cooldownToChallenge) {
+    badges.push({ type: 'cooldown' });
+  } else if (row.isMe) {
+    badges.push({ type: 'can-challenge' });
+  } else if (row.reptable) {
+    badges.push({
+      type: 'reptable',
+      canChallenge: !!row.canChallenge,
+      reason: row.reason ?? null
+    });
+  }
+
+  if (row.protected) {
+    badges.push({ type: 'protected' });
+  }
+
+  if (row.outside) {
+    badges.push({ type: 'outside' });
+  }
+
+  return badges;
+}
+
+export type PlayerBadgeDescriptor = {
+  state: PlayerBadgeState['type'];
+  element: 'span' | 'button';
+  className: string;
+  text: string;
+  title: string;
+  ariaLabel: string;
+  disabled?: boolean;
+};
+
+const CLASS_BY_TYPE: Record<PlayerBadgeState['type'], string> = {
+  self:
+    'ml-1 inline-block rounded-full bg-yellow-400 px-2.5 py-1 text-xs font-medium text-gray-900 align-middle',
+  'active-challenge':
+    'ml-1 inline-block rounded-full bg-red-600 px-2.5 py-1 text-xs font-medium text-white align-middle',
+  cooldown:
+    'ml-1 inline-block rounded-full bg-yellow-300 px-2.5 py-1 text-xs font-medium text-gray-900 align-middle',
+  'can-challenge':
+    'ml-1 inline-block rounded-full bg-green-600 px-2.5 py-1 text-xs font-medium text-white align-middle',
+  reptable:
+    'ml-1 rounded-full bg-blue-600 px-2.5 py-1 text-xs font-medium text-white align-middle disabled:opacity-50',
+  protected:
+    'ml-1 inline-block rounded-full bg-gray-400 px-2.5 py-1 text-xs font-medium text-white align-middle',
+  outside:
+    'ml-1 inline-block rounded-full bg-gray-200 px-2.5 py-1 text-xs font-medium text-gray-800 align-middle'
+};
+
+const TEXT_BY_TYPE: Record<PlayerBadgeState['type'], string> = {
+  self: 'Tu',
+  'active-challenge': 'Té repte actiu',
+  cooldown: 'No pot reptar',
+  'can-challenge': 'Pot reptar',
+  reptable: 'Reptable',
+  protected: 'Protegit',
+  outside: 'Fora de rànquing actiu'
+};
+
+const TITLE_BY_TYPE = (
+  badge: PlayerBadgeState
+): string => {
+  switch (badge.type) {
+    case 'self':
+      return 'Tu';
+    case 'active-challenge':
+      return 'Aquest jugador té un repte actiu (no pot iniciar-ne cap altre).';
+    case 'cooldown':
+      return 'En cooldown fins passats 7 dies del darrer repte disputat.';
+    case 'can-challenge':
+      return 'Pots reptar fins a 2 posicions per sobre teu.';
+    case 'reptable':
+      return badge.canChallenge
+        ? 'Aquest jugador és reptable per tu ara mateix.'
+        : badge.reason ?? 'No pots reptar';
+    case 'protected':
+      return 'Protegit (cooldown de ser reptat)';
+    case 'outside':
+      return 'Fora de rànquing actiu';
+  }
+  return '';
+};
+
+export function buildBadgeDescriptors(
+  row: PlayerBadgeSource,
+  provider: (source: PlayerBadgeSource) => PlayerBadgeState[] = getPlayerBadges
+): PlayerBadgeDescriptor[] {
+  return provider(row).map((badge) => {
+    const title = TITLE_BY_TYPE(badge);
+    return {
+      state: badge.type,
+      element: badge.type === 'reptable' ? 'button' : 'span',
+      className: CLASS_BY_TYPE[badge.type],
+      text: TEXT_BY_TYPE[badge.type],
+      title,
+      ariaLabel: title,
+      disabled: badge.type === 'reptable' ? !badge.canChallenge : undefined
+    } satisfies PlayerBadgeDescriptor;
+  });
+}

--- a/src/routes/classificacio/+page.svelte
+++ b/src/routes/classificacio/+page.svelte
@@ -1,25 +1,18 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
+  import PlayerBadges from '$lib/components/PlayerBadges.svelte';
   import { canCreateChallenge } from '$lib/canCreateChallenge';
+  import type { PlayerBadgeSource } from '$lib/playerBadges';
 
-  type Row = {
+  type Row = PlayerBadgeSource & {
     event_id: string;
     posicio: number | null;
-    player_id: string;
     nom: string;
     mitjana: number | null;
     estat: string;
     assignat_el: string | null;
-    isMe?: boolean;
-    hasActiveChallenge?: boolean;
-    cooldownToChallenge?: boolean;
     cooldownToBeChallenged?: boolean;
-    reptable?: boolean;
-    canChallenge?: boolean;
-    reason?: string | null;
-    protected?: boolean;
-    outside?: boolean;
   };
 
   const fmtSafe = (iso: string | null): string => {
@@ -234,62 +227,7 @@
             <td class="px-3 py-2">{r.posicio ?? '-'}</td>
             <td class="px-3 py-2">
               {r.nom}
-              {#if r.isMe}
-                <span
-                  class="ml-1 inline-block rounded-full bg-yellow-400 px-2.5 py-1 text-xs font-medium text-gray-900 align-middle"
-                  title="Tu"
-                  aria-label="Tu"
-                  >Tu</span
-                >
-              {/if}
-              {#if r.hasActiveChallenge}
-                <span
-                  class="ml-1 inline-block rounded-full bg-red-600 px-2.5 py-1 text-xs font-medium text-white align-middle"
-                  title="Aquest jugador té un repte actiu (no pot iniciar-ne cap altre)."
-                  aria-label="Aquest jugador té un repte actiu (no pot iniciar-ne cap altre)."
-                  >Té repte actiu</span
-                >
-              {:else if r.cooldownToChallenge}
-                <span
-                  class="ml-1 inline-block rounded-full bg-yellow-300 px-2.5 py-1 text-xs font-medium text-gray-900 align-middle"
-                  title="En cooldown fins passats 7 dies del darrer repte disputat."
-                  aria-label="En cooldown fins passats 7 dies del darrer repte disputat."
-                  >No pot reptar</span
-                >
-              {:else if r.isMe}
-                <span
-                  class="ml-1 inline-block rounded-full bg-green-600 px-2.5 py-1 text-xs font-medium text-white align-middle"
-                  title="Pots reptar fins a 2 posicions per sobre teu."
-                  aria-label="Pots reptar fins a 2 posicions per sobre teu."
-                  >Pot reptar</span
-                >
-              {:else if r.reptable}
-                <button
-                  class="ml-1 rounded-full bg-blue-600 px-2.5 py-1 text-xs font-medium text-white align-middle disabled:opacity-50"
-                  title={r.canChallenge ? 'Aquest jugador és reptable per tu ara mateix.' : r.reason || 'No pots reptar'}
-                  aria-label={r.canChallenge ? 'Aquest jugador és reptable per tu ara mateix.' : r.reason || 'No pots reptar'}
-                  disabled={!r.canChallenge}
-                  on:click={() => reptar(r.player_id)}
-                >
-                  Reptable
-                </button>
-              {/if}
-              {#if r.protected}
-                <span
-                  class="ml-1 inline-block rounded-full bg-gray-400 px-2.5 py-1 text-xs font-medium text-white align-middle"
-                  title="Protegit (cooldown de ser reptat)"
-                  aria-label="Protegit (cooldown de ser reptat)"
-                  >Protegit</span
-                >
-              {/if}
-              {#if r.outside}
-                <span
-                  class="ml-1 inline-block rounded-full bg-gray-200 px-2.5 py-1 text-xs font-medium text-gray-800 align-middle"
-                  title="Fora de rànquing actiu"
-                  aria-label="Fora de rànquing actiu"
-                  >Fora de rànquing actiu</span
-                >
-              {/if}
+              <PlayerBadges row={r} on:challenge={(event) => reptar(event.detail)} />
             </td>
             <td class="px-3 py-2">{r.mitjana ?? '-'}</td>
             <td class="px-3 py-2 capitalize">{r.estat.replace('_', ' ')}</td>
@@ -301,31 +239,66 @@
   </div>
   <div class="mt-2 flex flex-wrap gap-4 text-sm">
     <div class="flex items-center gap-1">
-      <span class="inline-block rounded-full bg-red-600 px-2.5 py-1 text-xs font-medium text-white">Té repte actiu</span>
+      <span
+        class="inline-block rounded-full bg-red-600 px-2.5 py-1 text-xs font-medium text-white"
+        aria-label="Té repte actiu"
+        title="Té repte actiu"
+        >Té repte actiu</span
+      >
       <span>té repte actiu</span>
     </div>
     <div class="flex items-center gap-1">
-      <span class="inline-block rounded-full bg-yellow-300 px-2.5 py-1 text-xs font-medium text-gray-900">No pot reptar</span>
+      <span
+        class="inline-block rounded-full bg-yellow-300 px-2.5 py-1 text-xs font-medium text-gray-900"
+        aria-label="No pot reptar (cooldown)"
+        title="No pot reptar (cooldown)"
+        >No pot reptar</span
+      >
       <span>no pot reptar (cooldown)</span>
     </div>
     <div class="flex items-center gap-1">
-      <span class="inline-block rounded-full bg-green-600 px-2.5 py-1 text-xs font-medium text-white">Pot reptar</span>
+      <span
+        class="inline-block rounded-full bg-green-600 px-2.5 py-1 text-xs font-medium text-white"
+        aria-label="Pot reptar"
+        title="Pot reptar"
+        >Pot reptar</span
+      >
       <span>pot reptar</span>
     </div>
     <div class="flex items-center gap-1">
-      <span class="inline-block rounded-full bg-blue-600 px-2.5 py-1 text-xs font-medium text-white">Reptable</span>
+      <span
+        class="inline-block rounded-full bg-blue-600 px-2.5 py-1 text-xs font-medium text-white"
+        aria-label="Reptable"
+        title="Reptable"
+        >Reptable</span
+      >
       <span>reptable</span>
     </div>
     <div class="flex items-center gap-1">
-      <span class="inline-block rounded-full bg-gray-400 px-2.5 py-1 text-xs font-medium text-white">Protegit</span>
+      <span
+        class="inline-block rounded-full bg-gray-400 px-2.5 py-1 text-xs font-medium text-white"
+        aria-label="Protegit"
+        title="Protegit"
+        >Protegit</span
+      >
       <span>protegit (no reptable)</span>
     </div>
     <div class="flex items-center gap-1">
-      <span class="inline-block rounded-full bg-gray-200 px-2.5 py-1 text-xs font-medium text-gray-800">Fora de rànquing actiu</span>
+      <span
+        class="inline-block rounded-full bg-gray-200 px-2.5 py-1 text-xs font-medium text-gray-800"
+        aria-label="Fora de rànquing actiu"
+        title="Fora de rànquing actiu"
+        >Fora de rànquing actiu</span
+      >
       <span>fora de rànquing actiu</span>
     </div>
     <div class="flex items-center gap-1">
-      <span class="inline-block rounded-full bg-yellow-400 px-2.5 py-1 text-xs font-medium text-gray-900">Tu</span>
+      <span
+        class="inline-block rounded-full bg-yellow-400 px-2.5 py-1 text-xs font-medium text-gray-900"
+        aria-label="Tu"
+        title="Tu"
+        >Tu</span
+      >
       <span>tu</span>
     </div>
   </div>

--- a/tests/__snapshots__/playerBadgesComponent.test.ts.snap
+++ b/tests/__snapshots__/playerBadgesComponent.test.ts.snap
@@ -1,0 +1,30 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`PlayerBadges descriptors > matches snapshot for multiple badges 1`] = `
+[
+  {
+    "ariaLabel": "Tu",
+    "className": "ml-1 inline-block rounded-full bg-yellow-400 px-2.5 py-1 text-xs font-medium text-gray-900 align-middle",
+    "disabled": false,
+    "element": "span",
+    "state": "self",
+    "text": "Tu",
+  },
+  {
+    "ariaLabel": "Aquest jugador té un repte actiu (no pot iniciar-ne cap altre).",
+    "className": "ml-1 inline-block rounded-full bg-red-600 px-2.5 py-1 text-xs font-medium text-white align-middle",
+    "disabled": false,
+    "element": "span",
+    "state": "active-challenge",
+    "text": "Té repte actiu",
+  },
+  {
+    "ariaLabel": "Protegit (cooldown de ser reptat)",
+    "className": "ml-1 inline-block rounded-full bg-gray-400 px-2.5 py-1 text-xs font-medium text-white align-middle",
+    "disabled": false,
+    "element": "span",
+    "state": "protected",
+    "text": "Protegit",
+  },
+]
+`;

--- a/tests/playerBadgesComponent.test.ts
+++ b/tests/playerBadgesComponent.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { PlayerBadgeState } from '../src/lib/playerBadges';
+import { buildBadgeDescriptors } from '../src/lib/playerBadges';
+
+const baseRow = { player_id: 'player-1' };
+
+const runWith = (states: PlayerBadgeState[]) => {
+  const provider = vi.fn().mockReturnValue(states);
+  const badges = buildBadgeDescriptors(baseRow as any, provider);
+  expect(provider).toHaveBeenCalledWith(baseRow);
+  return badges;
+};
+
+describe('PlayerBadges descriptors', () => {
+  it('creates active challenge badge descriptor', () => {
+    const [badge] = runWith([{ type: 'active-challenge' }]);
+    expect(badge.element).toBe('span');
+    expect(badge.text).toBe('Té repte actiu');
+    expect(badge.ariaLabel).toBe('Aquest jugador té un repte actiu (no pot iniciar-ne cap altre).');
+    expect(badge.className).toContain('bg-red-600');
+  });
+
+  it('creates cooldown badge descriptor', () => {
+    const [badge] = runWith([{ type: 'cooldown' }]);
+    expect(badge.text).toBe('No pot reptar');
+    expect(badge.ariaLabel).toBe('En cooldown fins passats 7 dies del darrer repte disputat.');
+    expect(badge.className).toContain('bg-yellow-300');
+  });
+
+  it('creates can-challenge descriptor for self', () => {
+    const [badge] = runWith([{ type: 'can-challenge' }]);
+    expect(badge.text).toBe('Pot reptar');
+    expect(badge.ariaLabel).toBe('Pots reptar fins a 2 posicions per sobre teu.');
+    expect(badge.className).toContain('bg-green-600');
+  });
+
+  it('creates enabled reptable descriptor', () => {
+    const states: PlayerBadgeState[] = [{ type: 'reptable', canChallenge: true, reason: 'Disponible' }];
+    const [badge] = runWith(states);
+    expect(badge.element).toBe('button');
+    expect(badge.text).toBe('Reptable');
+    expect(badge.ariaLabel).toBe('Aquest jugador és reptable per tu ara mateix.');
+    expect(badge.disabled).toBe(false);
+  });
+
+  it('creates disabled reptable descriptor', () => {
+    const states: PlayerBadgeState[] = [{ type: 'reptable', canChallenge: false, reason: 'No pots reptar' }];
+    const [badge] = runWith(states);
+    expect(badge.disabled).toBe(true);
+    expect(badge.ariaLabel).toBe('No pots reptar');
+  });
+
+  it('creates protected descriptor', () => {
+    const [badge] = runWith([{ type: 'protected' }]);
+    expect(badge.text).toBe('Protegit');
+    expect(badge.ariaLabel).toBe('Protegit (cooldown de ser reptat)');
+    expect(badge.className).toContain('bg-gray-400');
+  });
+
+  it('creates outside descriptor', () => {
+    const [badge] = runWith([{ type: 'outside' }]);
+    expect(badge.text).toBe('Fora de rànquing actiu');
+    expect(badge.ariaLabel).toBe('Fora de rànquing actiu');
+    expect(badge.className).toContain('bg-gray-200');
+  });
+
+  it('creates self descriptor', () => {
+    const [badge] = runWith([{ type: 'self' }]);
+    expect(badge.text).toBe('Tu');
+    expect(badge.ariaLabel).toBe('Tu');
+    expect(badge.className).toContain('bg-yellow-400');
+  });
+
+  it('matches snapshot for multiple badges', () => {
+    const states: PlayerBadgeState[] = [
+      { type: 'self' },
+      { type: 'active-challenge' },
+      { type: 'protected' }
+    ];
+    const provider = vi.fn().mockReturnValue(states);
+    const badges = buildBadgeDescriptors(baseRow as any, provider).map(({ state, element, text, ariaLabel, className, disabled }) => ({
+      state,
+      element,
+      text,
+      ariaLabel,
+      className,
+      disabled: disabled ?? false
+    }));
+    expect(badges).toMatchSnapshot();
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,44 +1,57 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { SvelteKitPWA } from '@vite-pwa/sveltekit';
+import { fileURLToPath, URL } from 'node:url';
 import { defineConfig } from 'vite';
 
+const isTest = process.env.NODE_ENV === 'test' || !!process.env.VITEST;
+
 export default defineConfig({
-  plugins: [
-    sveltekit(),
-    SvelteKitPWA({
-      registerType: 'autoUpdate',
-      manifest: {
-        name: 'Campionat 3 Bandes',
-        short_name: 'C3B',
-        start_url: '/',
-        display: 'standalone',
-        background_color: '#ffffff',
-        theme_color: '#0f172a',
-        icons: [
-          // Pots afegir icones reals a /static/icons/ si vols
-          // { src: '/icons/icon-192.png', sizes: '192x192', type: 'image/png' },
-          // { src: '/icons/icon-512.png', sizes: '512x512', type: 'image/png' }
-        ]
-      },
-      workbox: {
-        runtimeCaching: [
-          {
-            urlPattern: ({ request }) =>
-              ['style', 'script', 'image', 'font'].includes(request.destination),
-            handler: 'StaleWhileRevalidate',
-            options: { cacheName: 'assets-cache' }
+  plugins: isTest
+    ? []
+    : [
+        sveltekit(),
+        SvelteKitPWA({
+          registerType: 'autoUpdate',
+          manifest: {
+            name: 'Campionat 3 Bandes',
+            short_name: 'C3B',
+            start_url: '/',
+            display: 'standalone',
+            background_color: '#ffffff',
+            theme_color: '#0f172a',
+            icons: [
+              // Pots afegir icones reals a /static/icons/ si vols
+              // { src: '/icons/icon-192.png', sizes: '192x192', type: 'image/png' },
+              // { src: '/icons/icon-512.png', sizes: '512x512', type: 'image/png' }
+            ]
           },
-          {
-            urlPattern: ({ url }) => url.pathname.startsWith('/api'),
-            handler: 'NetworkFirst',
-            options: { cacheName: 'api-cache' }
+          workbox: {
+            runtimeCaching: [
+              {
+                urlPattern: ({ request }) =>
+                  ['style', 'script', 'image', 'font'].includes(request.destination),
+                handler: 'StaleWhileRevalidate',
+                options: { cacheName: 'assets-cache' }
+              },
+              {
+                urlPattern: ({ url }) => url.pathname.startsWith('/api'),
+                handler: 'NetworkFirst',
+                options: { cacheName: 'api-cache' }
+              }
+            ]
           }
-        ]
-      }
-    })
-  ],
+        })
+      ],
   define: {
     'import.meta.env.PUBLIC_SUPABASE_URL': JSON.stringify('https://qbldqtaqawnahuzlzsjs.supabase.co'),
     'import.meta.env.PUBLIC_SUPABASE_ANON_KEY': JSON.stringify('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFibGRxdGFxYXduYWh1emx6c2pzIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTcwNTkyMDgsImV4cCI6MjA3MjYzNTIwOH0.bLMQFuZkIRW3r41P18Y4eipu1nbNUx3_0QtpwyVZqN4')
+  },
+  resolve: {
+    alias: {
+      $lib: fileURLToPath(new URL('./src/lib', import.meta.url))
+    }
+  },
+  test: {
+    environment: 'node'
   }
 });


### PR DESCRIPTION
## Summary
- extract player badge logic into reusable utilities and a `PlayerBadges` component
- update the classificació table and legend badges with aria labels for accessibility
- add unit snapshot tests for badge descriptors and configure Vitest for headless execution

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68c87f2e1600832e871b543bafe9a163