### PR TITLE
feat: prefetch ranking badges on load

### DIFF
--- a/src/lib/server/daoAdmin.ts
+++ b/src/lib/server/daoAdmin.ts
@@ -1,4 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
+import type { VPlayerBadges } from '$lib/playerBadges';
+import { serverSupabase } from './supabaseAdmin';
 
 export type VChallengePending = {
   /** Identificador del repte */
@@ -95,6 +97,13 @@ export type VMaintenanceRunDetail = {
   /** Informació addicional del pas. */
   metadata: Record<string, unknown> | null;
 };
+
+export async function getPlayerBadges(): Promise<VPlayerBadges[]> {
+  const supabase = serverSupabase();
+  const { data, error } = await supabase.from('v_player_badges').select('*');
+  if (error) throw new Error(error.message);
+  return (data ?? []) as VPlayerBadges[];
+}
 
 export type UpdateSettingsInput = {
   diesAcceptar: number;

--- a/src/routes/ranking/+page.ts
+++ b/src/routes/ranking/+page.ts
@@ -1,0 +1,18 @@
+import type { PageLoad } from './$types';
+import type { VPlayerBadges } from '$lib/playerBadges';
+
+const emptyBadges: VPlayerBadges[] = [];
+
+export const load: PageLoad = async () => {
+  if (!import.meta.env.SSR) {
+    return { badges: emptyBadges, badgesLoaded: false };
+  }
+
+  try {
+    const { getPlayerBadges } = await import('$lib/server/daoAdmin');
+    const badges = await getPlayerBadges();
+    return { badges, badgesLoaded: true };
+  } catch (error) {
+    return { badges: emptyBadges, badgesLoaded: false };
+  }
+};


### PR DESCRIPTION
## Summary
- add a server-side `getPlayerBadges` helper so the ranking page can reuse the admin DAO
- prefetch player badges in the ranking load function with a client-side fallback when SSR is unavailable
- hydrate the ranking component with initial badges, avoid duplicate badge fetches, and keep penalty refreshes in sync

## Testing
- pnpm test
- pnpm check *(fails: existing duplicate identifier errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c884ace188832e91d8a1a2f95d8e64