### PR TITLE
Fix duplicate authFetch import in admin challenges page

### DIFF
--- a/src/routes/admin/reptes/+page.svelte
+++ b/src/routes/admin/reptes/+page.svelte
@@ -8,7 +8,6 @@
       import { formatSupabaseError, ok as okText, err as errText } from '$lib/ui/alerts';
       import { authFetch } from '$lib/utils/http';
       import { CHALLENGE_STATE_LABEL } from '$lib/ui/challengeState';
-      import { authFetch } from '$lib/utils/http';
 
 
 


### PR DESCRIPTION
## Summary
- remove the duplicate `authFetch` import from the admin challenges page to resolve the build error

## Testing
- pnpm run build *(fails: vite guard prevents importing server dao in browser)*

------
https://chatgpt.com/codex/tasks/task_e_68c8eea4cf2c832ea0034211a19068e1