### PR TITLE
Add badge accessibility helpers and tests

### DIFF
--- a/src/lib/badgeView.ts
+++ b/src/lib/badgeView.ts
@@ -1,0 +1,46 @@
+import { getPlayerBadges, type VPlayerBadges } from '$lib/playerBadges';
+
+export type BadgeView = {
+  label: string;
+  text: string;
+  className: string;
+};
+
+const ACTIVE_BADGE: BadgeView = {
+  label: 'Repte actiu',
+  text: 'Repte actiu',
+  className: 'rounded-full bg-blue-100 px-2 py-0.5 text-[11px] font-medium text-blue-700'
+};
+
+const COOLDOWN_BADGE: BadgeView = {
+  label: 'Cooldown',
+  text: 'Cooldown',
+  className: 'rounded-full bg-orange-100 px-2 py-0.5 text-[11px] font-medium text-orange-700'
+};
+
+const CHALLENGEABLE_BADGE: BadgeView = {
+  label: 'Es pot reptar',
+  text: 'Es pot reptar',
+  className: 'rounded-full bg-green-100 px-2 py-0.5 text-[11px] font-medium text-green-700'
+};
+
+export function getBadgeView(badge: VPlayerBadges | undefined | null): BadgeView | null {
+  if (!badge) return null;
+  if (badge.has_active_challenge) {
+    return ACTIVE_BADGE;
+  }
+  if (badge.in_cooldown) {
+    return COOLDOWN_BADGE;
+  }
+  if (badge.can_be_challenged) {
+    return CHALLENGEABLE_BADGE;
+  }
+  return null;
+}
+
+export async function fetchBadgeMap(
+  getBadges: () => Promise<VPlayerBadges[]> = getPlayerBadges
+): Promise<Map<string, VPlayerBadges>> {
+  const list = await getBadges();
+  return new Map(list.map((badge) => [badge.player_id, badge]));
+}

--- a/src/routes/ranking/+page.svelte
+++ b/src/routes/ranking/+page.svelte
@@ -4,7 +4,8 @@
     import { get } from 'svelte/store';
     import { canCreateChallenge } from '$lib/canCreateChallenge';
     import { ranking, refreshRanking, type RankingRow } from '$lib/rankingStore';
-    import { getPlayerBadges, type VPlayerBadges } from '$lib/playerBadges';
+    import { type VPlayerBadges } from '$lib/playerBadges';
+    import { fetchBadgeMap, getBadgeView } from '$lib/badgeView';
     import PlayerEvolutionModal from '$lib/components/PlayerEvolutionModal.svelte';
     import { adminStore } from '$lib/stores/auth';
     import { applyDisagreementDrop } from '$lib/applyDisagreementDrop';
@@ -129,8 +130,7 @@
       return;
     }
     try {
-      const list = await getPlayerBadges();
-      badgeMap = new Map<string, VPlayerBadges>(list.map((b) => [b.player_id, b]));
+      badgeMap = await fetchBadgeMap();
       shouldFetchBadges = false;
     } catch {
       if (force || shouldFetchBadges) {
@@ -243,26 +243,14 @@
                 >
                   {r.nom}
                 </button>
-                {#if badge?.has_active_challenge}
+                {@const badgeView = getBadgeView(badge)}
+                {#if badgeView}
                   <span
-                    class="rounded-full bg-blue-100 px-2 py-0.5 text-[11px] font-medium text-blue-700"
+                    class={badgeView.className}
+                    aria-label={badgeView.label}
                     title={badgeTooltip(badge) ?? undefined}
                   >
-                    Repte actiu
-                  </span>
-                {:else if badge?.in_cooldown}
-                  <span
-                    class="rounded-full bg-orange-100 px-2 py-0.5 text-[11px] font-medium text-orange-700"
-                    title={badgeTooltip(badge) ?? undefined}
-                  >
-                    Cooldown
-                  </span>
-                {:else if badge?.can_be_challenged}
-                  <span
-                    class="rounded-full bg-green-100 px-2 py-0.5 text-[11px] font-medium text-green-700"
-                    title={badgeTooltip(badge) ?? undefined}
-                  >
-                    Es pot reptar
+                    {badgeView.text}
                   </span>
                 {/if}
               </div>

--- a/tests/__snapshots__/rankingBadges.test.ts.snap
+++ b/tests/__snapshots__/rankingBadges.test.ts.snap
@@ -1,0 +1,3 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`badge rendering > produces consistent markup for the three badge states 1`] = `"<span class="rounded-full bg-blue-100 px-2 py-0.5 text-[11px] font-medium text-blue-700" aria-label="Repte actiu">Repte actiu</span><span class="rounded-full bg-orange-100 px-2 py-0.5 text-[11px] font-medium text-orange-700" aria-label="Cooldown">Cooldown</span><span class="rounded-full bg-green-100 px-2 py-0.5 text-[11px] font-medium text-green-700" aria-label="Es pot reptar">Es pot reptar</span>"`;

--- a/tests/rankingBadges.test.ts
+++ b/tests/rankingBadges.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fetchBadgeMap, getBadgeView } from '../src/lib/badgeView';
+import type { VPlayerBadges } from '../src/lib/playerBadges';
+
+describe('badge rendering', () => {
+  const badgeFixtures: VPlayerBadges[] = [
+    {
+      event_id: 'event-1',
+      player_id: 'p1',
+      posicio: 1,
+      last_play_date: '2024-01-01',
+      days_since_last: 0,
+      has_active_challenge: true,
+      in_cooldown: false,
+      can_be_challenged: false
+    },
+    {
+      event_id: 'event-1',
+      player_id: 'p2',
+      posicio: 2,
+      last_play_date: '2024-01-02',
+      days_since_last: 1,
+      has_active_challenge: false,
+      in_cooldown: true,
+      can_be_challenged: false
+    },
+    {
+      event_id: 'event-1',
+      player_id: 'p3',
+      posicio: 3,
+      last_play_date: '2024-01-03',
+      days_since_last: 2,
+      has_active_challenge: false,
+      in_cooldown: false,
+      can_be_challenged: true
+    }
+  ];
+
+  it('maps player badges to the correct view labels', async () => {
+    const mockGetBadges = vi.fn<[], Promise<VPlayerBadges[]>>().mockResolvedValue(badgeFixtures);
+
+    const map = await fetchBadgeMap(mockGetBadges);
+
+    expect(mockGetBadges).toHaveBeenCalledTimes(1);
+
+    const activeView = getBadgeView(map.get('p1'));
+    const cooldownView = getBadgeView(map.get('p2'));
+    const challengeableView = getBadgeView(map.get('p3'));
+
+    expect(activeView).not.toBeNull();
+    expect(activeView?.text).toBe('Repte actiu');
+    expect(activeView?.label).toBe('Repte actiu');
+
+    expect(cooldownView).not.toBeNull();
+    expect(cooldownView?.text).toBe('Cooldown');
+    expect(cooldownView?.label).toBe('Cooldown');
+
+    expect(challengeableView).not.toBeNull();
+    expect(challengeableView?.text).toBe('Es pot reptar');
+    expect(challengeableView?.label).toBe('Es pot reptar');
+  });
+
+  it('produces consistent markup for the three badge states', async () => {
+    const map = await fetchBadgeMap(async () => badgeFixtures);
+    const html = badgeFixtures
+      .map((badge) => {
+        const view = getBadgeView(map.get(badge.player_id));
+        if (!view) return '';
+        return `<span class="${view.className}" aria-label="${view.label}">${view.text}</span>`;
+      })
+      .join('');
+
+    expect(html).toMatchSnapshot();
+  });
+
+  it('returns null when there is no badge information', () => {
+    expect(getBadgeView(undefined)).toBeNull();
+    expect(getBadgeView(null)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared helper to generate badge maps and view metadata for ranking badges
- reuse the helper inside the ranking page to render badges with aria labels
- cover the badge states with unit and snapshot tests to ensure stable markup

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68c8ed833258832ebc7d93078889f02d