### PR TITLE
Fix admin maintenance RPC call

### DIFF
--- a/src/lib/deadlinesService.ts
+++ b/src/lib/deadlinesService.ts
@@ -1,6 +1,8 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 
 export type MaintenanceLogEntry = {
+  kind?: string | null;
+  payload?: Record<string, unknown> | null;
   challenges_processed?: number | null;
   challengesProcessed?: number | null;
   inactivity_processed?: number | null;
@@ -14,7 +16,7 @@ export type RunDeadlinesResult = {
   raw: MaintenanceLogEntry[];
 };
 
-const DEFAULT_ACTOR = 'admin:webapp';
+const DEFAULT_TRIGGERED_BY = 'admin:webapp';
 const CHALLENGE_KEYS = ['challenges_processed', 'challengesProcessed'];
 const INACTIVITY_KEYS = ['inactivity_processed', 'inactivityProcessed'];
 
@@ -24,16 +26,33 @@ function ensureArray<T>(value: T | T[] | null | undefined): T[] {
   return [value];
 }
 
-function extractCount(entry: MaintenanceLogEntry, keys: string[]): number {
-  for (const key of keys) {
-    const value = entry[key];
-    if (typeof value === 'number' && Number.isFinite(value)) {
-      return value;
+function parseNumericValue(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isFinite(parsed)) {
+      return parsed;
     }
-    if (typeof value === 'string') {
-      const parsed = Number.parseInt(value, 10);
-      if (Number.isFinite(parsed)) {
-        return parsed;
+  }
+  return null;
+}
+
+function extractCount(entry: MaintenanceLogEntry, keys: string[]): number {
+  const payload =
+    entry.payload && typeof entry.payload === 'object'
+      ? (entry.payload as Record<string, unknown>)
+      : null;
+  for (const key of keys) {
+    const direct = parseNumericValue(entry[key]);
+    if (direct != null) {
+      return direct;
+    }
+    if (payload) {
+      const nested = parseNumericValue(payload[key]);
+      if (nested != null) {
+        return nested;
       }
     }
   }
@@ -54,9 +73,9 @@ export async function runDeadlines(
   supabase: SupabaseClient,
   actorEmail?: string | null
 ): Promise<RunDeadlinesResult> {
-  const actor = actorEmail ? `admin:${actorEmail}` : DEFAULT_ACTOR;
+  const triggeredBy = actorEmail ? `admin:${actorEmail}` : DEFAULT_TRIGGERED_BY;
   const { data, error } = await supabase.rpc('admin_run_maintenance_and_log', {
-    p_actor: actor
+    p_triggered_by: triggeredBy
   });
   if (error) throw new Error(error.message);
   const raw = ensureArray<MaintenanceLogEntry>(data);

--- a/tests/deadlinesService.test.ts
+++ b/tests/deadlinesService.test.ts
@@ -3,12 +3,15 @@ import { runDeadlines } from '../src/lib/deadlinesService';
 
 describe('deadlinesService', () => {
   it('calls maintenance RPC and returns friendly result', async () => {
-    const payload = [{ challenges_processed: 2, inactivity_processed: 1 }];
+    const payload = [
+      { kind: 'challenges_overdue', payload: { challenges_processed: 2 } },
+      { kind: 'inactivity', payload: { inactivity_processed: 1 } }
+    ];
     const rpc = vi.fn().mockResolvedValue({ data: payload, error: null });
     const client = { rpc } as any;
     const res = await runDeadlines(client, 'admin@example.com');
     expect(rpc).toHaveBeenCalledWith('admin_run_maintenance_and_log', {
-      p_actor: 'admin:admin@example.com'
+      p_triggered_by: 'admin:admin@example.com'
     });
     expect(res).toEqual({
       challengesProcessed: 2,


### PR DESCRIPTION
## Summary
- update the maintenance RPC call to use the new `p_triggered_by` argument when running deadlines
- extract processed counts from the `{ kind, payload }` entries returned by the RPC
- adapt the deadlines service unit test to the new response shape

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68c90e55b3bc832ea8778e1e071c5cda