### PR TITLE
Fix waiting list page type definition

### DIFF
--- a/src/routes/llista-espera/+page.svelte
+++ b/src/routes/llista-espera/+page.svelte
@@ -7,7 +7,7 @@
     ordre: number;
     player_id: string;
     nom: string;
-
+  };
 
   // Eliminat fmtDate perquè data_inscripcio ja no es mostra
 


### PR DESCRIPTION
## Summary
- close the Row type definition on the waiting list page so the script compiles

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68c99871a954832e9be118d4a32b7edd