### PR TITLE
Avoid blocking ranking page load on challenge/badge checks

### DIFF
--- a/src/routes/ranking/+page.svelte
+++ b/src/routes/ranking/+page.svelte
@@ -95,9 +95,9 @@
       eventId = event.id as string;
 
       await refreshRanking();
-      await loadBadges();
+      void loadBadges();
       myPos = get(ranking).find((r) => r.player_id === myPlayerId)?.posicio ?? null;
-      await evaluateChallenges(supabaseClient);
+      void evaluateChallenges(supabaseClient);
     } catch (e: any) {
       error = e?.message ?? 'Error desconegut';
     } finally {


### PR DESCRIPTION
## Summary
- avoid awaiting badge fetching and challenge evaluation when the ranking page mounts so the table renders immediately

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68c99f573a60832ebcfef88dc3941a7a