### PR TITLE
Unifica el format dels noms a la classificació

### DIFF
--- a/src/lib/utils/playerName.ts
+++ b/src/lib/utils/playerName.ts
@@ -1,0 +1,105 @@
+const CONNECTOR_WORDS = new Set([
+  'de',
+  'del',
+  'la',
+  'les',
+  'lo',
+  'los',
+  'las',
+  'el',
+  'els',
+  'van',
+  'von',
+  'da',
+  'das',
+  'dos',
+  'des',
+  'dei',
+  'della',
+  'dalla',
+  'delle',
+  'dello',
+  'degli',
+  'di',
+  'do',
+  'y',
+  'i'
+]);
+
+function normalizeConnector(part: string): string {
+  return part
+    .trim()
+    .toLowerCase()
+    .replace(/[’']/g, '');
+}
+
+function splitParts(value: string): string[] {
+  return value
+    .trim()
+    .split(/[\s-]+/)
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+}
+
+function buildInitials(parts: string[]): string {
+  if (parts.length === 0) return '';
+
+  const filtered = parts.filter((part) => !CONNECTOR_WORDS.has(normalizeConnector(part)));
+  const relevant = filtered.length > 0 ? filtered : parts.slice(0, 1);
+
+  return relevant
+    .map((part) => part.charAt(0).toLocaleUpperCase('ca'))
+    .join('.');
+}
+
+function extractFirstSurname(cognoms: string): string {
+  const parts = splitParts(cognoms);
+  if (parts.length === 0) return '';
+
+  const surnameParts: string[] = [];
+  for (const part of parts) {
+    surnameParts.push(part);
+    if (!CONNECTOR_WORDS.has(normalizeConnector(part))) {
+      break;
+    }
+  }
+
+  return surnameParts.join(' ');
+}
+
+/**
+ * Format a player name as "Inicials. Primer cognom". Works with composed names
+ * and surnames that include connector words (de, del, van, ...).
+ */
+export function formatPlayerDisplayName(nom: string, cognoms?: string | null): string {
+  const safeNom = nom?.trim() ?? '';
+  const safeCognoms = cognoms?.trim() ?? '';
+
+  if (!safeNom && !safeCognoms) {
+    return '';
+  }
+
+  const firstNameParts = splitParts(safeNom);
+  const initials = buildInitials(firstNameParts);
+
+  if (safeCognoms) {
+    const surname = extractFirstSurname(safeCognoms);
+    if (initials && surname) return `${initials}. ${surname}`;
+    if (initials) return `${initials}.`;
+    return surname;
+  }
+
+  if (firstNameParts.length === 1) {
+    return firstNameParts[0];
+  }
+
+  const surnameFallback = firstNameParts[firstNameParts.length - 1];
+  const givenNames = firstNameParts.slice(0, -1);
+  const fallbackInitials = buildInitials(givenNames);
+
+  if (fallbackInitials && surnameFallback) {
+    return `${fallbackInitials}. ${surnameFallback}`;
+  }
+
+  return safeNom;
+}

--- a/src/routes/classificacio/+page.svelte
+++ b/src/routes/classificacio/+page.svelte
@@ -2,11 +2,13 @@
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
   import { canCreateChallenge } from '$lib/canCreateChallenge';
+  import { formatPlayerDisplayName } from '$lib/utils/playerName';
 
   type Row = {
     posicio: number;
     player_id: string;
     nom: string;
+    cognoms: string | null;
     mitjana: number | null;
     estat: string;
     event_id?: string;
@@ -55,6 +57,7 @@
         const base = (data as Row[]) ?? [];
         rows = base.map((r) => ({
           ...r,
+          cognoms: r.cognoms ?? null,
           isMe: myPlayerId === r.player_id,
           hasActiveChallenge: false,
           cooldownToChallenge: false,
@@ -298,7 +301,12 @@
             <td class="px-3 py-2">{r.posicio}</td>
             <td class="px-3 py-2">
               <div class="flex items-center gap-2">
-                <span class="font-medium text-gray-900">{r.nom}</span>
+                <span
+                  class="font-medium text-gray-900"
+                  title={r.cognoms ? `${r.nom} ${r.cognoms}` : r.nom}
+                >
+                  {formatPlayerDisplayName(r.nom, r.cognoms)}
+                </span>
                 
                 <!-- Badges d'estat -->
                 {#if r.isMe}

--- a/src/routes/ranking/+page.svelte
+++ b/src/routes/ranking/+page.svelte
@@ -12,6 +12,7 @@
     import { adminStore } from '$lib/stores/auth';
     import { applyDisagreementDrop } from '$lib/applyDisagreementDrop';
     import PullToRefresh from '$lib/components/gestures/PullToRefresh.svelte';
+    import { formatPlayerDisplayName } from '$lib/utils/playerName';
 
   export let badges: VPlayerBadges[] = [];
   export let badgesLoaded = false;
@@ -236,37 +237,6 @@
   const fmtMitjana = (m: number | null) => (m == null ? '-' : String(m));
   const fmtEstat = (e: string | undefined | null) => (e ? e.replace('_', ' ') : '');
 
-  // Funció per escurçar noms: inicials + primer cognom
-  const shortenName = (nom: string, cognoms: string | null): string => {
-    if (!nom) return '';
-
-    // Si tenim cognoms separats, usar-los
-    if (cognoms) {
-      // Agafar les inicials dels noms
-      const nameInitials = nom.trim().split(/\s+/)
-        .map(name => name.charAt(0).toUpperCase())
-        .join('.');
-
-      // Agafar el primer cognom
-      const firstSurname = cognoms.trim().split(/\s+/)[0];
-
-      return `${nameInitials}. ${firstSurname}`;
-    }
-
-    // Fallback: usar el nom complet com abans
-    const parts = nom.trim().split(/\s+/);
-    if (parts.length === 1) return parts[0]; // Només un nom
-
-    // Assumim que l'últim element és el cognom principal
-    const surname = parts[parts.length - 1];
-
-    // Els elements anteriors són noms
-    const firstNames = parts.slice(0, -1);
-    const initials = firstNames.map(name => name.charAt(0).toUpperCase()).join('.');
-
-    return `${initials}. ${surname}`;
-  };
-
   async function applyPenalty() {
     if (!(eventId && selA && selB && Math.abs(selA - selB) === 1)) return;
     penaltyBusy = true;
@@ -355,7 +325,7 @@
                   class:font-bold={r.player_id === myPlayerId}
                   title={r.cognoms ? `${r.nom} ${r.cognoms}` : r.nom}
                 >
-                  {shortenName(r.nom, r.cognoms)}
+                  {formatPlayerDisplayName(r.nom, r.cognoms)}
                 </button>
 
                 <!-- Badge per identificar el jugador logat -->
@@ -434,7 +404,7 @@
             <option value={null} disabled selected>Selecciona posició</option>
             {#each rows as r}
               <option value={r.posicio} title={r.cognoms ? `${r.nom} ${r.cognoms}` : r.nom}>
-                {r.posicio} - {shortenName(r.nom, r.cognoms)}
+                {r.posicio} - {formatPlayerDisplayName(r.nom, r.cognoms)}
               </option>
             {/each}
           </select>
@@ -445,7 +415,7 @@
             <option value={null} disabled selected>Selecciona posició</option>
             {#each rows as r}
               <option value={r.posicio} title={r.cognoms ? `${r.nom} ${r.cognoms}` : r.nom}>
-                {r.posicio} - {shortenName(r.nom, r.cognoms)}
+                {r.posicio} - {formatPlayerDisplayName(r.nom, r.cognoms)}
               </option>
             {/each}
           </select>


### PR DESCRIPTION
## Summary
- crea utilitats compartides per construir el format abreujat del nom i cognoms
- aplica el format abreujat tant a la pàgina pública de classificació com al rànquing principal perquè siguin coherents

## Testing
- npm run check *(falla per errors preexistents a fitxers no modificats)*

------
https://chatgpt.com/codex/tasks/task_e_68d22a9f7cb8832e930f8aac68f61f11