### PR TITLE
Gestió de resultats i programació del hàndicap alineada amb socials

### DIFF
--- a/src/lib/components/gestio-partides/UnifiedScheduleModal.svelte
+++ b/src/lib/components/gestio-partides/UnifiedScheduleModal.svelte
@@ -16,12 +16,21 @@
   export let match: UnifiedMatch | null = null;
   export let saving: boolean = false;
   export let supabase: SupabaseClient;
+  /**
+   * Destí de l'enllaç "planificador complet" (només hàndicap). Si és null,
+   * l'enllaç es converteix en un botó que emet `openPlanner` en lloc de
+   * navegar — així la pàgina /handicap/partides pot expandir el slot-picker
+   * ric en línia. Per defecte navega a /handicap/partides (comportament de
+   * /admin/partides, intacte).
+   */
+  export let plannerHref: string | null = '/handicap/partides';
 
   // ── Dispatcher ────────────────────────────────────────────────────────────────
 
   const dispatch = createEventDispatcher<{
     save: UnifiedSlot;
     unschedule: void;
+    openPlanner: void;
     close: void;
   }>();
 
@@ -212,9 +221,15 @@
 
         {#if handicapMeta}
           <div class="info-box">
-            <a href="/handicap/partides" class="info-link">
-              Obrir el planificador complet →
-            </a>
+            {#if plannerHref}
+              <a href={plannerHref} class="info-link">
+                Obrir el planificador complet →
+              </a>
+            {:else}
+              <button type="button" class="info-link info-link-btn" on:click={() => dispatch('openPlanner')}>
+                Obrir el planificador complet →
+              </button>
+            {/if}
           </div>
         {/if}
 
@@ -447,6 +462,14 @@
     text-decoration: underline;
   }
   .info-link:hover { opacity: 0.75; }
+  .info-link-btn {
+    background: transparent;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    font-family: var(--font-sans);
+    text-align: left;
+  }
 
   /* Pista de disponibilitat (hàndicap) */
   .avail-hint {

--- a/src/lib/services/matchManagement/handicapAdapter.ts
+++ b/src/lib/services/matchManagement/handicapAdapter.ts
@@ -48,6 +48,94 @@ function buildPlayer(
   };
 }
 
+// ── Mapatge a UnifiedMatch (font única) ──────────────────────────────────────
+
+/**
+ * Dades planes d'una partida hàndicap, suficients per construir un
+ * `UnifiedMatch`. Tant `listMatches` (que les llegeix de la BD) com les pàgines
+ * del mòdul hàndicap (que ja les tenen carregades en memòria) en construeixen
+ * una instància i criden `buildHandicapUnifiedMatch`, de manera que la lògica
+ * de `capabilities` i la forma de `meta` viuen en un sol lloc.
+ */
+export interface HandicapMatchViewInput {
+  id: string;
+  estat: string;
+  bracketType: 'winners' | 'losers' | 'grand_final';
+  ronda: number;
+  matchPos: number;
+  matchCode: string;
+  calendariPartidaId: string | null;
+  eventId: string;
+  eventNom: string;
+  sistemaPuntuacio: string;
+  limitEntrades: number | null;
+  player1: HandicapPlayerViewInput;
+  player2: HandicapPlayerViewInput;
+  /** null si la partida no té data/hora assignades */
+  slot: { dataIso: string; hora: string; billar: number | null } | null;
+}
+
+export interface HandicapPlayerViewInput {
+  displayName: string;
+  rawName: string;
+  sociNumero: number | null;
+  participantId: string | null;
+  distancia: number | null;
+  preferencies: { dies: string[]; hores: string[] } | null;
+}
+
+/**
+ * Construeix un `UnifiedMatch` hàndicap a partir de dades planes. Pur (sense
+ * Supabase). Centralitza la lògica de `mapEstat`, `capabilities` i `meta`.
+ */
+export function buildHandicapUnifiedMatch(input: HandicapMatchViewInput): UnifiedMatch {
+  const status = mapEstat(input.estat);
+  const bothResolved = !!(input.player1.participantId && input.player2.participantId);
+
+  const meta: HandicapMeta = {
+    source: 'handicap',
+    eventId: input.eventId,
+    eventNom: input.eventNom,
+    bracketType: input.bracketType,
+    ronda: input.ronda,
+    matchPos: input.matchPos,
+    matchCode: input.matchCode,
+    calendariPartidaId: input.calendariPartidaId,
+    player1ParticipantId: input.player1.participantId,
+    player2ParticipantId: input.player2.participantId,
+    player1Distancia: input.player1.distancia,
+    player2Distancia: input.player2.distancia,
+    sistemaPuntuacio: input.sistemaPuntuacio,
+    limitEntrades: input.limitEntrades,
+    player1Preferencies: input.player1.preferencies,
+    player2Preferencies: input.player2.preferencies
+  };
+
+  return {
+    source: 'handicap',
+    id: input.id,
+    player1: {
+      displayName: input.player1.displayName,
+      rawName: input.player1.rawName,
+      sociNumero: input.player1.sociNumero
+    },
+    player2: {
+      displayName: input.player2.displayName,
+      rawName: input.player2.rawName,
+      sociNumero: input.player2.sociNumero
+    },
+    slot: input.slot,
+    status,
+    rawEstat: input.estat,
+    capabilities: {
+      canEnterResult: status === 'programada' && bothResolved,
+      canSchedule: status === 'pendent' || status === 'programada',
+      canUnschedule: !!input.calendariPartidaId
+    },
+    meta
+  } satisfies UnifiedMatch;
+}
+
 // ── Adaptador ──────────────────────────────────────────────────────────────
 
 export const handicapAdapter: MatchAdapter = {
@@ -191,18 +279,14 @@ export const handicapAdapter: MatchAdapter = {
         const s1Data = getSociNom(p1);
         const s2Data = getSociNom(p2);
 
-        const player1: UnifiedPlayer = {
-          displayName: p1Name,
-          rawName: `${s1Data.nom ?? ''} ${s1Data.cognoms ?? ''}`.trim() || p1Name,
-          sociNumero: p1?.soci_numero ?? null
-        };
-        const player2: UnifiedPlayer = {
-          displayName: p2Name,
-          rawName: `${s2Data.nom ?? ''} ${s2Data.cognoms ?? ''}`.trim() || p2Name,
-          sociNumero: p2?.soci_numero ?? null
+        const buildPref = (p: any | null): { dies: string[]; hores: string[] } | null => {
+          if (!p) return null;
+          const dies: string[] = Array.isArray(p.preferencies_dies) ? (p.preferencies_dies as string[]) : [];
+          const hores: string[] = Array.isArray(p.preferencies_hores) ? (p.preferencies_hores as string[]) : [];
+          return { dies, hores };
         };
 
-        let slot = null;
+        let slot: { dataIso: string; hora: string; billar: number | null } | null = null;
         if (partida?.data_programada && partida?.hora_inici) {
           slot = {
             dataIso: (partida.data_programada as string).substring(0, 10),
@@ -211,51 +295,36 @@ export const handicapAdapter: MatchAdapter = {
           };
         }
 
-        const status = mapEstat(m.estat as string);
-        const bothResolved = !!(slot1?.participant_id && slot2?.participant_id);
-
-        const buildPref = (p: any | null): { dies: string[]; hores: string[] } | null => {
-          if (!p) return null;
-          const dies: string[] = Array.isArray(p.preferencies_dies) ? (p.preferencies_dies as string[]) : [];
-          const hores: string[] = Array.isArray(p.preferencies_hores) ? (p.preferencies_hores as string[]) : [];
-          return { dies, hores };
-        };
-
-        const meta: HandicapMeta = {
-          source: 'handicap',
-          eventId,
-          eventNom,
+        return buildHandicapUnifiedMatch({
+          id: m.id as string,
+          estat: m.estat as string,
           bracketType: (slot1?.bracket_type ?? 'winners') as HandicapMeta['bracketType'],
           ronda: (slot1?.ronda ?? 1) as number,
           matchPos,
           matchCode,
           calendariPartidaId: m.calendari_partida_id ?? null,
-          player1ParticipantId: slot1?.participant_id ?? null,
-          player2ParticipantId: slot2?.participant_id ?? null,
-          player1Distancia: p1?.distancia ?? (m.distancia_jugador1 as number | null) ?? null,
-          player2Distancia: p2?.distancia ?? (m.distancia_jugador2 as number | null) ?? null,
+          eventId,
+          eventNom,
           sistemaPuntuacio,
           limitEntrades,
-          player1Preferencies: buildPref(p1),
-          player2Preferencies: buildPref(p2)
-        };
-
-        // Capabilities: no podem entrar resultat si un jugador no és determinat
-        const canEnterResult = status === 'programada' && bothResolved;
-        const canSchedule = status === 'pendent' || status === 'programada';
-        const canUnschedule = !!(m.calendari_partida_id);
-
-        return {
-          source: 'handicap' as const,
-          id: m.id as string,
-          player1,
-          player2,
-          slot,
-          status,
-          rawEstat: m.estat as string,
-          capabilities: { canEnterResult, canSchedule, canUnschedule },
-          meta
-        } satisfies UnifiedMatch;
+          player1: {
+            displayName: p1Name,
+            rawName: `${s1Data.nom ?? ''} ${s1Data.cognoms ?? ''}`.trim() || p1Name,
+            sociNumero: p1?.soci_numero ?? null,
+            participantId: slot1?.participant_id ?? null,
+            distancia: p1?.distancia ?? (m.distancia_jugador1 as number | null) ?? null,
+            preferencies: buildPref(p1)
+          },
+          player2: {
+            displayName: p2Name,
+            rawName: `${s2Data.nom ?? ''} ${s2Data.cognoms ?? ''}`.trim() || p2Name,
+            sociNumero: p2?.soci_numero ?? null,
+            participantId: slot2?.participant_id ?? null,
+            distancia: p2?.distancia ?? (m.distancia_jugador2 as number | null) ?? null,
+            preferencies: buildPref(p2)
+          },
+          slot
+        });
       });
 
     return matches;

--- a/src/lib/services/matchManagement/index.ts
+++ b/src/lib/services/matchManagement/index.ts
@@ -34,6 +34,10 @@ export type {
 // Re-exports d'adaptadors (per si algun caller vol cridar-los directament)
 export { socialAdapter, continuAdapter, handicapAdapter };
 
+// Helper de mapatge hàndicap (reutilitzat per les pàgines del mòdul hàndicap)
+export { buildHandicapUnifiedMatch } from './handicapAdapter';
+export type { HandicapMatchViewInput, HandicapPlayerViewInput } from './handicapAdapter';
+
 // ── Registre d'adaptadors ──────────────────────────────────────────────────
 
 export const adapters: Record<MatchSource, MatchAdapter> = {

--- a/src/routes/handicap/partides/+page.svelte
+++ b/src/routes/handicap/partides/+page.svelte
@@ -7,12 +7,16 @@
 	import HandicapBranchBalance from '$lib/components/handicap/HandicapBranchBalance.svelte';
 	import HandicapWeeklyCalendar from '$lib/components/handicap/HandicapWeeklyCalendar.svelte';
 	import HandicapCalendarGridView from '$lib/components/handicap/HandicapCalendarGridView.svelte';
-	import HandicapMatchResult from '$lib/components/handicap/HandicapMatchResult.svelte';
 	import type { CalendarEntry, BranchMatchInput } from '$lib/utils/handicap-types';
 	import { buildMatchCodeMap, buildSlotSourceMap } from '$lib/utils/handicap-types';
 	import { computeDeadlines } from '$lib/utils/handicap-deadlines';
-	import { saveMatchResult, type SaveResultError } from '$lib/utils/handicap-propagation';
+	import { saveMatchResult } from '$lib/utils/handicap-propagation';
 	import { showConfirm } from '$lib/stores/confirmDialogStore';
+	import UnifiedResultModal from '$lib/components/gestio-partides/UnifiedResultModal.svelte';
+	import UnifiedScheduleModal from '$lib/components/gestio-partides/UnifiedScheduleModal.svelte';
+	import { adapters, buildHandicapUnifiedMatch } from '$lib/services/matchManagement';
+	import type { UnifiedMatch, ResultInput, UnifiedSlot } from '$lib/services/matchManagement';
+	import { showSuccess, showError } from '$lib/stores/toastStore';
 	import {
 		scheduleMatches,
 		type MatchToSchedule,
@@ -25,7 +29,7 @@
 	import { persistFullSchedule } from '$lib/utils/handicap-schedule-persist';
 	import { loadBlockedDates } from '$lib/utils/handicap-blocked-dates';
 	import { formatarNomJugadorParts } from '$lib/utils/playerUtils';
-	import { scheduleHandicapMatch, unscheduleHandicapMatch } from '$lib/utils/handicap-manual-schedule';
+	import { scheduleHandicapMatch } from '$lib/utils/handicap-manual-schedule';
 	import { checkCompatibility, type CompatibilityIssue, type CompatibilityMatchInput, type AlternativeSlot } from '$lib/utils/handicap-compatibility';
 	import HandicapCompatibilityCheckModal from '$lib/components/handicap/HandicapCompatibilityCheckModal.svelte';
 
@@ -85,8 +89,15 @@
 
 	let resultMatchId: string | null = null;
 	$: resultMatch = resultMatchId ? matches.find((m) => m.id === resultMatchId) ?? null : null;
+	$: resultUnified = resultMatch ? toUnified(resultMatch) : null;
 	let resultSaving = false;
-	let resultConfirmation: string | null = null;
+
+	// ── Modal de programació ───────────────────────────────────────────────────
+
+	let scheduleMatchId: string | null = null;
+	$: scheduleMatch = scheduleMatchId ? matches.find((m) => m.id === scheduleMatchId) ?? null : null;
+	$: scheduleUnified = scheduleMatch ? toUnified(scheduleMatch) : null;
+	let scheduleSaving = false;
 
 	// ── Filtres ───────────────────────────────────────────────────────────────
 
@@ -476,29 +487,48 @@
 		}
 	}
 
-	async function unschedule(match: MatchDisplay) {
-		if (!match.calendari_partida_id || saving) return;
-		const ok = await showConfirm({
-			title: 'Desassignar partida',
-			message: `Desassignar la partida ${match.player1_name} vs ${match.player2_name}?`,
-			severity: 'warning',
-			confirmLabel: 'Desassignar'
-		});
-		if (!ok) return;
-		saving = true;
-		error = null;
+	// ── Helpers UnifiedMatch ──────────────────────────────────────────────────
 
-		try {
-			await unscheduleHandicapMatch(supabase, {
-				matchId: match.id,
-				calendariPartidaId: match.calendari_partida_id
-			});
-			await loadData();
-		} catch (e: any) {
-			error = e.message;
-		} finally {
-			saving = false;
-		}
+	function prefOf(participantId: string | null): { dies: string[]; hores: string[] } | null {
+		if (!participantId) return null;
+		const p = participantMap.get(participantId);
+		if (!p) return null;
+		return { dies: p.preferencies_dies ?? [], hores: p.preferencies_hores ?? [] };
+	}
+
+	function toUnified(m: MatchDisplay): UnifiedMatch {
+		return buildHandicapUnifiedMatch({
+			id: m.id,
+			estat: m.estat,
+			bracketType: m.bracket_type,
+			ronda: m.ronda,
+			matchPos: m.matchPos,
+			matchCode: m.matchCode,
+			calendariPartidaId: m.calendari_partida_id,
+			eventId: eventId ?? '',
+			eventNom: '',
+			sistemaPuntuacio,
+			limitEntrades,
+			player1: {
+				displayName: m.player1_name,
+				rawName: m.player1_name,
+				sociNumero: m.player1_soci_numero,
+				participantId: m.player1_participant_id,
+				distancia: m.player1_distancia,
+				preferencies: prefOf(m.player1_participant_id)
+			},
+			player2: {
+				displayName: m.player2_name,
+				rawName: m.player2_name,
+				sociNumero: m.player2_soci_numero,
+				participantId: m.player2_participant_id,
+				distancia: m.player2_distancia,
+				preferencies: prefOf(m.player2_participant_id)
+			},
+			slot: (m.data_programada && m.hora_inici)
+				? { dataIso: m.data_programada, hora: m.hora_inici, billar: m.taula_assignada }
+				: null
+		});
 	}
 
 	// ── Auto-programació ──────────────────────────────────────────────────────
@@ -582,20 +612,10 @@
 
 	// ── Introducció de resultats ────────────────────────────────────────────────
 
-	async function handleResultConfirm(
-		e: CustomEvent<{
-			isWalkover: boolean;
-			caramboles1: number | null;
-			caramboles2: number | null;
-			entrades: number | null;
-			winnerParticipantId: string;
-			loserParticipantId: string;
-		}>
-	) {
+	async function handleResultSave(e: CustomEvent<ResultInput>) {
 		const match = resultMatch;
-		if (!match) return;
+		if (!match || e.detail.kind !== 'handicap') return;
 		resultSaving = true;
-		error = null;
 
 		const result = await saveMatchResult(supabase, {
 			matchId: match.id,
@@ -612,7 +632,7 @@
 		resultMatchId = null;
 
 		if (!result.ok) {
-			error = (result as SaveResultError).error;
+			showError((result as import('$lib/utils/handicap-propagation').SaveResultError).error);
 			return;
 		}
 
@@ -622,19 +642,56 @@
 
 		if (result.isChampion) {
 			estatCompeticio = 'finalitzat';
-			resultConfirmation = `🏆 ${winnerName} és el CAMPIÓ del torneig! El torneig s'ha tancat.`;
+			showSuccess(`${winnerName} és el CAMPIÓ del torneig! El torneig s'ha tancat.`);
 		} else if (result.needsResetMatch) {
-			resultConfirmation = `⚡ ${winnerName} guanya la Gran Final! Cal jugar el Reset Match (GF-R2) — ambdós jugadors estan assignats a la nova partida.`;
+			showSuccess(`${winnerName} guanya la Gran Final! Cal jugar el Reset Match (GF-R2) — ambdós jugadors estan assignats a la nova partida.`);
 		} else {
-			resultConfirmation = `Resultat registrat. ${winnerName} guanya i avança a ${result.winnerDestDesc}.${
+			showSuccess(`Resultat registrat. ${winnerName} guanya i avança a ${result.winnerDestDesc}.${
 				result.newSchedulableCount > 0
 					? ` ${result.newSchedulableCount} nova${result.newSchedulableCount !== 1 ? 'es' : ''} partida${result.newSchedulableCount !== 1 ? 'des' : ''} llesta${result.newSchedulableCount !== 1 ? 'es' : ''} per programar.`
 					: ''
-			}`;
+			}`);
 		}
 
 		await loadData();
-		setTimeout(() => (resultConfirmation = null), result.isChampion ? 30000 : 8000);
+	}
+
+	// ── Programació via modal unificat ────────────────────────────────────────
+
+	async function handleScheduleSave(e: CustomEvent<UnifiedSlot>) {
+		if (!scheduleUnified) return;
+		scheduleSaving = true;
+		try {
+			await adapters.handicap.schedule!(supabase, scheduleUnified, e.detail);
+			showSuccess('Partida programada correctament.');
+			scheduleMatchId = null;
+			await loadData();
+		} catch (err) {
+			showError(err instanceof Error ? err.message : 'Error programant la partida.');
+		} finally {
+			scheduleSaving = false;
+		}
+	}
+
+	async function handleScheduleUnschedule() {
+		if (!scheduleUnified) return;
+		scheduleSaving = true;
+		try {
+			await adapters.handicap.unschedule!(supabase, scheduleUnified);
+			showSuccess('Partida desprogramada.');
+			scheduleMatchId = null;
+			await loadData();
+		} catch (err) {
+			showError(err instanceof Error ? err.message : 'Error desprogramant.');
+		} finally {
+			scheduleSaving = false;
+		}
+	}
+
+	function handleOpenPlanner() {
+		const id = scheduleMatchId;
+		scheduleMatchId = null;
+		if (id && !isFinalitzat) schedulingMatchId = id;
 	}
 
 	// ── onMount ───────────────────────────────────────────────────────────────
@@ -751,15 +808,15 @@
 				: `Conflictes detectats: ${hardCount} durs (assignats), ${hourCount} risc d'hora, ${dayCount} risc de dia.\n`
 					+ r.warnings.slice(0, 8).map(w => `  • ${w.bracket}-R${w.ronda} ${w.scheduledDate} ${w.scheduledHora}: ${w.message}`).join('\n')
 					+ (r.warnings.length > 8 ? `\n  … (${r.warnings.length - 8} més)` : '');
-			alert(
-				`Programats: ${r.programats} (${r.nous} nous, ${r.actualitzats} actualitzats)\n`
-				+ `Data fi efectiva: ${r.dataFiEfectiva ?? '—'}\n`
-				+ (r.errors.length > 0 ? `Errors:\n${r.errors.slice(0, 5).join('\n')}\n` : '')
+			showSuccess(
+				`Programats: ${r.programats} (${r.nous} nous, ${r.actualitzats} actualitzats). `
+				+ `Data fi efectiva: ${r.dataFiEfectiva ?? '—'}. `
+				+ (r.errors.length > 0 ? `Errors: ${r.errors.slice(0, 5).join('; ')}. ` : '')
 				+ warningSummary
 			);
 			location.reload();
 		} catch (e: any) {
-			alert(`Error: ${e?.message ?? e}`);
+			showError(`Error: ${e?.message ?? e}`);
 		} finally {
 			regenerantHorari = false;
 		}
@@ -805,7 +862,7 @@
 			});
 			showCompatModal = true;
 		} catch (e: any) {
-			alert(`Error revisant: ${e?.message ?? e}`);
+			showError(`Error revisant: ${e?.message ?? e}`);
 		} finally {
 			checkingCompat = false;
 		}
@@ -959,18 +1016,6 @@
 		{#if error}
 			<div class="mb-4 rounded border border-red-300 bg-red-50 p-3 text-sm text-red-800 whitespace-pre-wrap">
 				{error}
-			</div>
-		{/if}
-
-		{#if resultConfirmation}
-			<div class="mb-4 flex items-start gap-3 rounded-lg border border-green-300 bg-green-50 px-4 py-3">
-				<span class="text-lg">✅</span>
-				<p class="flex-1 text-sm font-medium text-green-800">{resultConfirmation}</p>
-				<button
-					type="button"
-					on:click={() => (resultConfirmation = null)}
-					class="text-green-600 hover:text-green-800"
-				>✕</button>
 			</div>
 		{/if}
 
@@ -1268,22 +1313,23 @@
 								</td>
 								<td class="px-3 py-2 text-right">
 									{#if $effectiveIsAdmin}
-									{#if !isFinalitzat && (match.estat === 'pendent' || match.estat === 'programada')}
-										{#if config}
-											{#if schedulingMatchId === match.id}
+										<div class="flex justify-end gap-1.5">
+											{#if !isFinalitzat && match.estat === 'programada' && match.player1_participant_id && match.player2_participant_id}
 												<button
 													type="button"
-													on:click={() => (schedulingMatchId = null)}
-													class="rounded border border-gray-300 bg-white px-2 py-1 text-xs text-gray-600 hover:bg-gray-50"
+													on:click={() => (resultMatchId = match.id)}
+													disabled={saving || scheduleSaving || resultSaving}
+													class="action-btn action-btn-primary"
 												>
-													Tancar
+													Resultat
 												</button>
-											{:else}
+											{/if}
+											{#if !isFinalitzat && (match.estat === 'pendent' || match.estat === 'programada')}
 												<button
 													type="button"
-													on:click={() => (schedulingMatchId = match.id)}
-													disabled={saving}
-													class="rounded border border-purple-300 bg-purple-50 px-2 py-1 text-xs text-purple-700 hover:bg-purple-100 disabled:opacity-50"
+													on:click={() => (scheduleMatchId = match.id)}
+													disabled={saving || scheduleSaving || resultSaving}
+													class="action-btn action-btn-secondary"
 													title={match.player1_participant_id && match.player2_participant_id
 														? ''
 														: 'Pre-reserva: data orientativa (rival per determinar)'}
@@ -1291,29 +1337,8 @@
 													{match.data_programada ? 'Reprogramar' : 'Programar'}
 												</button>
 											{/if}
-										{/if}
-										{#if match.calendari_partida_id}
-											<button
-												type="button"
-												on:click={() => unschedule(match)}
-												disabled={saving}
-												class="ml-1 rounded border border-red-200 bg-red-50 px-2 py-1 text-xs text-red-600 hover:bg-red-100 disabled:opacity-50"
-											>
-												Desassignar
-											</button>
-										{/if}
+										</div>
 									{/if}
-									{#if !isFinalitzat && match.estat === 'programada' && match.player1_participant_id && match.player2_participant_id}
-										<button
-											type="button"
-											on:click={() => (resultMatchId = match.id)}
-											disabled={saving || resultSaving}
-											class="ml-1 rounded border border-green-300 bg-green-50 px-2 py-1 text-xs font-medium text-green-700 hover:bg-green-100 disabled:opacity-50"
-										>
-											Resultat
-										</button>
-									{/if}
-									{/if}<!-- end isAdmin -->
 								</td>
 							</tr>
 
@@ -1382,49 +1407,28 @@
 </div>
 
 <!-- ── Modal d'introducció de resultat ────────────────────────────────────── -->
-{#if $effectiveIsAdmin && resultMatch}
-	<!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
-	<div
-		class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-		on:click|self={() => (resultMatchId = null)}
-	>
-		<div
-			class="w-full max-w-md rounded-lg bg-white shadow-xl flex flex-col max-h-[90vh]"
-			on:click|stopPropagation
-			role="dialog"
-			aria-modal="true"
-			tabindex="-1"
-		>
-			<div class="flex items-center justify-between border-b border-gray-200 px-5 py-4">
-				<div>
-					<h2 class="font-semibold text-gray-900">Introduir resultat</h2>
-					<p class="text-xs text-gray-500">
-						{BRACKET_LABELS[resultMatch.bracket_type]} R{resultMatch.ronda} · Pos {resultMatch.matchPos}
-					</p>
-				</div>
-				<button
-					type="button"
-					on:click={() => (resultMatchId = null)}
-					class="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
-				>✕</button>
-			</div>
-			<div class="px-5 py-4">
-				<HandicapMatchResult
-					player1Name={resultMatch.player1_name}
-					player2Name={resultMatch.player2_name}
-					player1Distancia={resultMatch.player1_distancia}
-					player2Distancia={resultMatch.player2_distancia}
-					player1ParticipantId={resultMatch.player1_participant_id!}
-					player2ParticipantId={resultMatch.player2_participant_id!}
-					{sistemaPuntuacio}
-					{limitEntrades}
-					saving={resultSaving}
-					on:confirm={handleResultConfirm}
-					on:cancel={() => (resultMatchId = null)}
-				/>
-			</div>
-		</div>
-	</div>
+{#if $effectiveIsAdmin && resultUnified}
+	<UnifiedResultModal
+		match={resultUnified}
+		saving={resultSaving}
+		{supabase}
+		on:save={handleResultSave}
+		on:close={() => (resultMatchId = null)}
+	/>
+{/if}
+
+<!-- ── Modal de programació ────────────────────────────────────────────────── -->
+{#if $effectiveIsAdmin && scheduleUnified}
+	<UnifiedScheduleModal
+		match={scheduleUnified}
+		saving={scheduleSaving}
+		{supabase}
+		plannerHref={null}
+		on:save={handleScheduleSave}
+		on:unschedule={handleScheduleUnschedule}
+		on:openPlanner={handleOpenPlanner}
+		on:close={() => (scheduleMatchId = null)}
+	/>
 {/if}
 
 {#if showCompatModal && $effectiveIsAdmin}
@@ -1570,4 +1574,33 @@
 		box-shadow: inset 4px 0 0 0 #d97706;
 		transition: background 0.3s, box-shadow 0.3s;
 	}
+
+	/* Botons editorials d'acció per fila (mirall de /admin/partides) */
+	.action-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-height: 44px;
+		padding: 0.35rem 0.75rem;
+		font-family: var(--font-sans);
+		font-size: 0.75rem;
+		font-weight: 600;
+		cursor: pointer;
+		border-radius: 0;
+		transition: opacity 0.1s;
+		white-space: nowrap;
+	}
+	.action-btn:disabled { opacity: 0.45; cursor: not-allowed; }
+	.action-btn-primary {
+		background: var(--ink);
+		color: var(--paper);
+		border: 1px solid var(--ink);
+	}
+	.action-btn-primary:hover:not(:disabled) { opacity: 0.85; }
+	.action-btn-secondary {
+		background: transparent;
+		color: var(--ink);
+		border: 1px solid var(--rule-strong);
+	}
+	.action-btn-secondary:hover:not(:disabled) { border-color: var(--ink); }
 </style>

--- a/src/routes/handicap/quadre/+page.svelte
+++ b/src/routes/handicap/quadre/+page.svelte
@@ -7,12 +7,15 @@
 	import HandicapBracketView from '$lib/components/handicap/HandicapBracketView.svelte';
 	import HandicapBracketViewCompact from '$lib/components/handicap/HandicapBracketViewCompact.svelte';
 	import HandicapBracketPrintModal from '$lib/components/handicap/HandicapBracketPrintModal.svelte';
-	import HandicapMatchResult from '$lib/components/handicap/HandicapMatchResult.svelte';
+	import UnifiedResultModal from '$lib/components/gestio-partides/UnifiedResultModal.svelte';
 	import type { MatchView, PlayerInfo, BranchMatchInput } from '$lib/utils/handicap-types';
 	import { buildMatchCodeMap, buildLoserDestCodeMap, buildSlotSourceMap } from '$lib/utils/handicap-types';
 	import { computeDeadlines } from '$lib/utils/handicap-deadlines';
 	import { saveMatchResult, closeTournamentManual } from '$lib/utils/handicap-propagation';
 	import type { SaveResultError } from '$lib/utils/handicap-propagation';
+	import { buildHandicapUnifiedMatch } from '$lib/services/matchManagement';
+	import type { UnifiedMatch, ResultInput } from '$lib/services/matchManagement';
+	import { showSuccess, showError } from '$lib/stores/toastStore';
 	import { formatarNomJugadorParts } from '$lib/utils/playerUtils';
 	import { generateDoublEliminationBracket } from '$lib/utils/handicap-bracket-generator';
 	import { validateBracket } from '$lib/utils/handicap-bracket-validator';
@@ -54,9 +57,6 @@
 	let closingTournament = false;
 	let showPrintBracketModal = false;
 
-	// Resultat modal
-	let showResultForm = false;
-
 	// ── Numeració de partides ────────────────────────────────────────────────
 
 	$: matchCodeMap = buildMatchCodeMap(matchViews);
@@ -71,8 +71,11 @@
 	}
 
 	let resultSaving = false;
-	let resultConfirmation: string | null = null;
-	let quadreError: string | null = null;
+
+	// Modal de resultat unificat (separat del modal de detall)
+	let resultMatchId: string | null = null;
+	$: resultMatchView = resultMatchId ? (matchViews.find((m) => m.id === resultMatchId) ?? null) : null;
+	$: resultUnified = resultMatchView ? toUnified(resultMatchView) : null;
 
 	// ── Admin ─────────────────────────────────────────────────────────────────
 
@@ -396,28 +399,58 @@
 
 	function openMatch(match: MatchView) {
 		selectedMatchId = match.id;
-		showResultForm = false;
 	}
 
 	function closeModal() {
 		selectedMatchId = null;
-		showResultForm = false;
 	}
 
-	async function handleResultConfirm(
-		e: CustomEvent<{
-			isWalkover: boolean;
-			caramboles1: number | null;
-			caramboles2: number | null;
-			entrades: number | null;
-			winnerParticipantId: string;
-			loserParticipantId: string;
-		}>
-	) {
-		const match = selectedMatch;
+	// ── toUnified: converteix un MatchView a UnifiedMatch per al modal ────────
+
+	function toUnified(m: MatchView): UnifiedMatch {
+		const slot = m.data_hora
+			? (() => {
+					const [d, h] = m.data_hora!.split(' ');
+					return { dataIso: d, hora: h, billar: m.taula ? Number(m.taula) : null };
+				})()
+			: null;
+		return buildHandicapUnifiedMatch({
+			id: m.id,
+			estat: m.estat,
+			bracketType: m.bracket_type,
+			ronda: m.ronda,
+			matchPos: m.matchPos,
+			matchCode: matchCodeMap.get(m.id) ?? '',
+			calendariPartidaId: m.calendari_partida_id,
+			eventId: event?.id ?? '',
+			eventNom: '',
+			sistemaPuntuacio,
+			limitEntrades,
+			player1: {
+				displayName: m.player1?.shortName ?? m.player1?.name ?? 'Jugador 1',
+				rawName: m.player1?.name ?? 'Jugador 1',
+				sociNumero: (m.player1 as any)?.soci_numero ?? null,
+				participantId: m.slot1.participant_id,
+				distancia: m.distancia_jugador1 ?? m.player1?.distancia ?? null,
+				preferencies: null
+			},
+			player2: {
+				displayName: m.player2?.shortName ?? m.player2?.name ?? 'Jugador 2',
+				rawName: m.player2?.name ?? 'Jugador 2',
+				sociNumero: (m.player2 as any)?.soci_numero ?? null,
+				participantId: m.slot2.participant_id,
+				distancia: m.distancia_jugador2 ?? m.player2?.distancia ?? null,
+				preferencies: null
+			},
+			slot
+		});
+	}
+
+	async function handleResultSave(e: CustomEvent<ResultInput>) {
+		if (e.detail.kind !== 'handicap') return;
+		const match = resultMatchView;
 		if (!match || !event) return;
 		resultSaving = true;
-		quadreError = null;
 
 		const result = await saveMatchResult(supabase, {
 			matchId: match.id,
@@ -431,10 +464,9 @@
 		});
 
 		resultSaving = false;
-		closeModal();
 
 		if (!result.ok) {
-			quadreError = (result as SaveResultError).error;
+			showError((result as SaveResultError).error);
 			return;
 		}
 
@@ -450,21 +482,21 @@
 			estatCompeticio = 'finalitzat';
 			championName = winnerName;
 			subchampionName = loserName;
-			resultConfirmation = `🏆 ${winnerName} és el CAMPIÓ del torneig! El torneig s'ha tancat.`;
+			showSuccess(`${winnerName} és el CAMPIÓ del torneig! El torneig s'ha tancat.`);
 		} else if (result.needsResetMatch) {
-			resultConfirmation = `⚡ ${winnerName} guanya la Gran Final! Cal jugar el Reset Match (GF-R2) perquè queden igualats.`;
+			showSuccess(`${winnerName} guanya la Gran Final! Cal jugar el Reset Match (GF-R2) perquè queden igualats.`);
 		} else {
-			let msg = `✅ ${winnerName} guanya i avança a ${result.winnerDestDesc}.`;
+			let msg = `${winnerName} guanya i avança a ${result.winnerDestDesc}.`;
 			if (result.autoScheduled && result.autoScheduled.scheduled > 0) {
-				msg += ` 📅 ${result.autoScheduled.scheduled} partida${result.autoScheduled.scheduled !== 1 ? 's' : ''} programada${result.autoScheduled.scheduled !== 1 ? 'des' : ''} automàticament.`;
+				msg += ` ${result.autoScheduled.scheduled} partida${result.autoScheduled.scheduled !== 1 ? 's' : ''} programada${result.autoScheduled.scheduled !== 1 ? 'des' : ''} automàticament.`;
 			} else if (result.autoScheduled && result.autoScheduled.conflicts > 0) {
-				msg += ` ⚠️ ${result.autoScheduled.conflicts} partida${result.autoScheduled.conflicts !== 1 ? 'des' : ''} amb conflicte de calendari — programa-les manualment.`;
+				msg += ` ${result.autoScheduled.conflicts} partida${result.autoScheduled.conflicts !== 1 ? 'des' : ''} amb conflicte de calendari — programa-les manualment.`;
 			}
-			resultConfirmation = msg;
+			showSuccess(msg);
 		}
 
+		resultMatchId = null;
 		await loadBracketData(event.id);
-		setTimeout(() => (resultConfirmation = null), result.isChampion ? 30000 : 8000);
 	}
 
 	async function handleCloseTournament() {
@@ -478,20 +510,18 @@
 		});
 		if (!confirmed) return;
 		closingTournament = true;
-		quadreError = null;
 		const result = await closeTournamentManual(supabase, event.id);
 		closingTournament = false;
 		if (!result.ok) {
 			if (result.pendingCount && result.pendingCount > 0) {
-				quadreError = `No es pot tancar: queden ${result.pendingCount} partides sense jugar.`;
+				showError(`No es pot tancar: queden ${result.pendingCount} partides sense jugar.`);
 			} else {
-				quadreError = result.error ?? 'Error tancant el torneig.';
+				showError(result.error ?? 'Error tancant el torneig.');
 			}
 			return;
 		}
 		estatCompeticio = 'finalitzat';
-		resultConfirmation = 'Torneig tancat correctament.';
-		setTimeout(() => (resultConfirmation = null), 5000);
+		showSuccess('Torneig tancat correctament.');
 	}
 
 	function matchBracketLabel(m: MatchView): string {
@@ -621,8 +651,8 @@
 					<button
 						type="button"
 						on:click={() => filter = val as typeof filter}
-						class="px-3 py-1.5 transition-colors
-							{filter === val ? 'bg-purple-600 text-white font-medium' : 'text-gray-600 hover:bg-gray-50'}"
+						class="px-3 py-1.5 transition-colors filter-chip
+							{filter === val ? 'filter-chip-active' : 'text-gray-600 hover:bg-gray-50'}"
 					>
 						{label}
 					</button>
@@ -635,7 +665,7 @@
 					type="text"
 					bind:value={searchTerm}
 					placeholder="Cerca jugador..."
-					class="w-full rounded border border-gray-300 bg-white px-3 py-1.5 text-sm shadow-sm focus:border-purple-400 focus:outline-none focus:ring-1 focus:ring-purple-400"
+					class="w-full rounded border border-gray-300 bg-white px-3 py-1.5 text-sm shadow-sm focus:border-gray-600 focus:outline-none focus:ring-1 focus:ring-gray-600"
 				/>
 				{#if searchTerm}
 					<button
@@ -811,67 +841,32 @@
 				{/if}
 			</div>
 
-		<!-- Formulari de resultat (inline) — només admins -->
-		{#if $effectiveIsAdmin && showResultForm && selectedMatch.estat === 'programada' && selectedMatch.slot1.participant_id && selectedMatch.slot2.participant_id}
-			<div class="border-t border-gray-200 px-5 py-4">
-				<HandicapMatchResult
-					player1Name={selectedMatch.player1?.shortName ?? 'Jugador 1'}
-					player2Name={selectedMatch.player2?.shortName ?? 'Jugador 2'}
-					player1Distancia={selectedMatch.distancia_jugador1 ?? selectedMatch.player1?.distancia ?? null}
-					player2Distancia={selectedMatch.distancia_jugador2 ?? selectedMatch.player2?.distancia ?? null}
-					player1ParticipantId={selectedMatch.slot1.participant_id}
-					player2ParticipantId={selectedMatch.slot2.participant_id}
-					{sistemaPuntuacio}
-					{limitEntrades}
-					saving={resultSaving}
-					on:confirm={handleResultConfirm}
-					on:cancel={() => (showResultForm = false)}
-				/>
-			</div>
-		{:else}
-			<!-- Botons d'acció -->
-			<div class="border-t border-gray-200 px-5 py-4 flex gap-2 justify-end">
-				<a
-					href="/handicap/partides"
-					class="rounded border border-purple-300 bg-purple-50 px-4 py-2 text-sm font-medium text-purple-700 hover:bg-purple-100"
-				>
+		<!-- Botons d'acció -->
+			<div class="modal-actions border-t border-gray-200 px-5 py-4 flex gap-2 justify-end">
+				<a href="/handicap/partides" class="btn-modal-secondary">
 					Programar
 				</a>
 				{#if $effectiveIsAdmin && selectedMatch.estat === 'programada' && selectedMatch.slot1.participant_id && selectedMatch.slot2.participant_id && !isFinalitzat}
 					<button
 						type="button"
-						on:click={() => (showResultForm = true)}
-						class="rounded border border-green-300 bg-green-50 px-4 py-2 text-sm font-medium text-green-700 hover:bg-green-100"
+						on:click={() => { const id = selectedMatch?.id; closeModal(); if (id) resultMatchId = id; }}
+						class="btn-modal-primary"
 					>
 						Introduir resultat
 					</button>
 				{/if}
-				<button
-					type="button"
-					on:click={closeModal}
-					class="rounded bg-gray-100 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200"
-				>
+				<button type="button" on:click={closeModal} class="btn-modal-secondary">
 					Tancar
 				</button>
 			</div>
-		{/if}
 	</div>
 </div>
 {/if}
 
-<!-- ── Confirmació resultat ───────────────────────────────────────────── -->
-{#if resultConfirmation}
-	<div class="fixed bottom-4 right-4 z-40 max-w-sm rounded-lg border border-green-300 bg-green-50 px-4 py-3 shadow-lg">
-		<p class="text-sm font-medium text-green-800">{resultConfirmation}</p>
-	</div>
-{/if}
-{#if quadreError}
-	<div class="fixed bottom-4 right-4 z-40 max-w-sm rounded-lg border border-red-300 bg-red-50 px-4 py-3 shadow-lg">
-		<div class="flex items-start gap-2">
-			<p class="flex-1 text-sm text-red-800">{quadreError}</p>
-			<button type="button" on:click={() => (quadreError = null)} class="text-red-500">✕</button>
-		</div>
-	</div>
+<!-- ── Modal resultat unificat ────────────────────────────────────────────── -->
+{#if $effectiveIsAdmin && resultUnified}
+	<UnifiedResultModal match={resultUnified} saving={resultSaving} {supabase}
+		on:save={handleResultSave} on:close={() => (resultMatchId = null)} />
 {/if}
 
 {#if showPrintBracketModal && event}
@@ -939,6 +934,36 @@
 		cursor: pointer; min-height: 36px;
 	}
 	.btn-action:hover { border-color: var(--ink); }
+
+	/* Botons editorials del modal de detall */
+	.btn-modal-primary {
+		background: var(--ink); color: var(--paper);
+		border: 1px solid var(--ink);
+		padding: 0.4rem 0.9rem;
+		font-family: var(--font-sans);
+		font-weight: 600; font-size: 0.875rem;
+		cursor: pointer; min-height: 40px;
+	}
+	.btn-modal-primary:hover { opacity: 0.85; }
+
+	.btn-modal-secondary {
+		background: transparent; color: var(--ink);
+		border: 1px solid var(--rule-strong);
+		padding: 0.4rem 0.9rem;
+		font-family: var(--font-sans);
+		font-weight: 500; font-size: 0.875rem;
+		text-decoration: none; display: inline-flex; align-items: center;
+		cursor: pointer; min-height: 40px;
+	}
+	.btn-modal-secondary:hover { border-color: var(--ink); }
+
+	/* Filtre de bracket: estat actiu en tinta editorial */
+	.filter-chip { font-family: var(--font-sans); }
+	.filter-chip-active {
+		background: var(--ink) !important;
+		color: var(--paper) !important;
+		font-weight: 600;
+	}
 
 	.state-empty {
 		padding: 1.5rem 1.75rem;


### PR DESCRIPTION
## Gestió de resultats i programació del hàndicap alineada amb socials

Fa que introduir resultats i (re)programar partides al mòdul **hàndicap** tingui el **mateix aspecte i ubicació de botons** que a campionats socials, reutilitzant els modals unificats i l'adaptador de la PR #190 (no es duplica UI ni es toca la lògica de BD).

### Canvis
- **`/handicap/partides`**: fila d'accions amb **"Resultat"** (primari ink) i **"Programar"/"Reprogramar"** (secundari contornejat), idèntica a `/admin/partides`. El resultat obre `UnifiedResultModal` (que incrusta `HandicapMatchResult`); la programació obre `UnifiedScheduleModal` (Data+Hora+Billar) amb **"Desprogramar"** dins del modal. Es treu l'estètica lila i els `alert()` passen a **toasts**.
- **Modal simple per defecte + planificador ric a demanda**: la graella setmanal amb disponibilitat (`HandicapSlotPicker`) es manté i s'obre via l'enllaç "Obrir el planificador complet →" (i pel deep-link `?focus=`).
- **`/handicap/quadre`**: el modal de detall conserva la info del bracket (seed, destí del perdedor) però **"Introduir resultat" obre el mateix `UnifiedResultModal`**. "Programar" segueix enllaçant al planificador, restilitzat. Banners flotants → toasts; filtre de bracket actiu sense lila.
- **Fonaments**: helper `buildHandicapUnifiedMatch` extret a `handicapAdapter` (font única de la lògica `capabilities`/`meta`; `listMatches` i `/admin/partides` el segueixen exercitant) i prop retrocompatible `plannerHref`/event `openPlanner` a `UnifiedScheduleModal`.

### Decisions (acordades)
- Restilitzar les pàgines del mòdul hàndicap **i** mantenir `/admin/partides` com a alternativa centralitzada.
- Programació: **modal simple per defecte + enllaç al planificador ric** per a casos avançats.

### Verificació
- `npm run check` **0/0** després de cada increment · `npm run build` correcte · smoke amb navegador real: cap crash de runtime a cap de les dues pàgines.
- **Pendent de prova manual** (cal sessió admin + torneig actiu): entrar resultat (normal + walkover, cas campió), programar simple amb conflicte de billar, obrir el planificador ric, reprogramar i desprogramar, a `/handicap/partides` i `/handicap/quadre`. La richesa hàndicap (auto-schedule, incompatibilitats, regenerar horari, branch balance) es manté intacta.

Sense migracions ni secrets nous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
