### PR TITLE
feat(admin): estadístiques d'accés a seccions/pàgines

### DIFF
--- a/src/lib/api/pageViews.ts
+++ b/src/lib/api/pageViews.ts
@@ -1,0 +1,96 @@
+import { supabase } from '$lib/supabaseClient';
+
+export interface PageViewTotals {
+  total_views: number;
+  unique_visitors: number;
+  authed_views: number;
+  anon_views: number;
+}
+
+export interface SectionStat {
+  section: string;
+  views: number;
+  visitors: number;
+  authed_views: number;
+}
+
+export interface DailyStat {
+  day: string; // 'YYYY-MM-DD'
+  views: number;
+  visitors: number;
+}
+
+export interface TopPath {
+  path: string;
+  section: string;
+  views: number;
+  visitors: number;
+}
+
+interface RangeOpts {
+  fromISO: string;
+  toISO: string;
+  includeAdmin: boolean;
+}
+
+/** Etiquetes en català per a cada secció derivada. */
+export const SECTION_LABELS: Record<string, string> = {
+  inici: 'Inici',
+  general: 'General',
+  'campionats-socials': 'Campionats socials',
+  'campionat-continu': 'Rànquing continu',
+  handicap: 'Hàndicap',
+  admin: 'Administració',
+  jugador: 'Perfils de jugador',
+  altres: 'Altres'
+};
+
+export function sectionLabel(section: string): string {
+  return SECTION_LABELS[section] ?? section;
+}
+
+export async function getPageViewTotals(opts: RangeOpts): Promise<PageViewTotals> {
+  const { data, error } = await supabase.rpc('get_page_view_totals', {
+    p_from: opts.fromISO,
+    p_to: opts.toISO,
+    p_include_admin: opts.includeAdmin
+  });
+  if (error) throw error;
+  const row = (data ?? [])[0] as PageViewTotals | undefined;
+  return (
+    row ?? { total_views: 0, unique_visitors: 0, authed_views: 0, anon_views: 0 }
+  );
+}
+
+export async function getSectionStats(opts: RangeOpts): Promise<SectionStat[]> {
+  const { data, error } = await supabase.rpc('get_page_view_section_stats', {
+    p_from: opts.fromISO,
+    p_to: opts.toISO,
+    p_include_admin: opts.includeAdmin
+  });
+  if (error) throw error;
+  return (data ?? []) as SectionStat[];
+}
+
+export async function getDailyStats(opts: RangeOpts): Promise<DailyStat[]> {
+  const { data, error } = await supabase.rpc('get_page_view_daily', {
+    p_from: opts.fromISO,
+    p_to: opts.toISO,
+    p_include_admin: opts.includeAdmin
+  });
+  if (error) throw error;
+  return (data ?? []) as DailyStat[];
+}
+
+export async function getTopPaths(
+  opts: RangeOpts & { limit?: number }
+): Promise<TopPath[]> {
+  const { data, error } = await supabase.rpc('get_page_view_top_paths', {
+    p_from: opts.fromISO,
+    p_to: opts.toISO,
+    p_include_admin: opts.includeAdmin,
+    p_limit: opts.limit ?? 20
+  });
+  if (error) throw error;
+  return (data ?? []) as TopPath[];
+}

--- a/src/lib/components/admin/UsageChart.svelte
+++ b/src/lib/components/admin/UsageChart.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import * as echarts from 'echarts';
+
+  export let option: echarts.EChartsOption;
+  export let height = 320;
+
+  let dom: HTMLDivElement;
+  let chart: echarts.ECharts | null = null;
+
+  function refresh() {
+    if (chart && option) chart.setOption(option, true);
+  }
+
+  onMount(() => {
+    chart = echarts.init(dom);
+    refresh();
+    const onResize = () => chart?.resize();
+    window.addEventListener('resize', onResize);
+    return () => {
+      window.removeEventListener('resize', onResize);
+      chart?.dispose();
+      chart = null;
+    };
+  });
+
+  $: if (chart && option) refresh();
+</script>
+
+<div bind:this={dom} class="usage-chart" style="height:{height}px"></div>
+
+<style>
+  .usage-chart {
+    width: 100%;
+    background: var(--paper-elevated, #fff);
+    border: 1px solid var(--rule, #e6e3dc);
+  }
+</style>

--- a/src/lib/components/general/NavEditorial.svelte
+++ b/src/lib/components/general/NavEditorial.svelte
@@ -100,7 +100,8 @@
         { href: '/admin/socis', label: 'Gestió de socis' },
         { href: '/admin/events', label: 'Events' },
         { href: '/admin/categories', label: 'Categories' },
-        { href: '/admin/audit-log', label: "Registre d'auditoria" }
+        { href: '/admin/audit-log', label: "Registre d'auditoria" },
+        { href: '/admin/estadistiques-acces', label: "Estadístiques d'accés" }
       ],
       adminOnly: true
     }

--- a/src/lib/utils/page-view-tracking.ts
+++ b/src/lib/utils/page-view-tracking.ts
@@ -1,0 +1,73 @@
+import { afterNavigate } from '$app/navigation';
+import { browser, dev } from '$app/environment';
+
+/**
+ * Registre anònim de visites de pàgina per a estadístiques d'ús (admin).
+ *
+ * - Només desa la secció/path i flags agregats (no cap identitat d'usuari).
+ * - Genera un `visitor_id` aleatori per navegador (localStorage) per estimar
+ *   visitants únics sense identificar ningú.
+ * - És "fire and forget": mai bloqueja la navegació ni propaga errors.
+ * - No registra res en desenvolupament (per no contaminar les dades de prod).
+ */
+
+const VISITOR_KEY = 'c3b_visitor_id';
+
+function getVisitorId(): string | null {
+  if (!browser) return null;
+  try {
+    let id = localStorage.getItem(VISITOR_KEY);
+    if (!id) {
+      id =
+        typeof crypto !== 'undefined' && 'randomUUID' in crypto
+          ? crypto.randomUUID()
+          : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      localStorage.setItem(VISITOR_KEY, id);
+    }
+    return id;
+  } catch {
+    // localStorage pot no estar disponible (mode privat, etc.)
+    return null;
+  }
+}
+
+let lastPath: string | null = null;
+
+// Si el registre falla repetidament (p. ex. la migració encara no s'ha aplicat
+// a producció), deshabilitem el tracking per a la resta de la sessió i així no
+// generem peticions fallides a cada navegació.
+let failures = 0;
+let disabled = false;
+const MAX_FAILURES = 3;
+
+async function track(path: string): Promise<void> {
+  if (disabled) return;
+  try {
+    const { supabase } = await import('$lib/supabaseClient');
+    const { error } = await supabase.rpc('log_page_view', {
+      p_path: path,
+      p_visitor_id: getVisitorId()
+    });
+    if (error) {
+      if (++failures >= MAX_FAILURES) disabled = true;
+    } else {
+      failures = 0;
+    }
+  } catch {
+    // Analytics no ha de trencar mai l'app: empassem qualsevol error.
+    if (++failures >= MAX_FAILURES) disabled = true;
+  }
+}
+
+export function setupPageViewTracking(): void {
+  if (!browser) return;
+
+  afterNavigate(({ to }) => {
+    const path = to?.url?.pathname;
+    if (!path) return;
+    if (path === lastPath) return; // evita duplicats en re-render
+    lastPath = path;
+    if (dev) return; // no registrar en desenvolupament
+    void track(path);
+  });
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -7,6 +7,7 @@
   import { pwaManager } from '$lib/connection/pwa-integration';
   import '$lib/config/pwa-config'; // Importar configuració PWA per suprimir errors
   import { setupFocusManagement } from "$lib/utils/focus-management";
+  import { setupPageViewTracking } from "$lib/utils/page-view-tracking";
   import Toasts from '$lib/components/general/Toasts.svelte';
   import ToastContainer from '$lib/components/general/ToastContainer.svelte';
   import ConfirmDialog from '$lib/components/general/ConfirmDialog.svelte';
@@ -148,6 +149,9 @@
 
     // Configura gestió del focus per accessibilitat
     setupFocusManagement();
+
+    // Registre anònim de visites de pàgina (estadístiques d'ús per a admins)
+    setupPageViewTracking();
 
     // Escoltar actualitzacions de PWA
     window.addEventListener('pwa-update-available', (event) => {

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -348,6 +348,12 @@
           <p class="ad-card-body">Histori de canvis al rànquing, reptes i estats dels jugadors.</p>
         </a>
 
+        <a href="/admin/estadistiques-acces" class="ad-card">
+          <div class="ad-card-eyebrow">Informació</div>
+          <h3 class="ad-card-title">Estadístiques d'accés</h3>
+          <p class="ad-card-body">Visites per secció, evolució diària i pàgines més vistes. Dades agregades i anònimes.</p>
+        </a>
+
         <!-- Widget: penalitzacions -->
         <div class="ad-card ad-card-widget">
           <div class="ad-card-eyebrow">Acció puntual</div>

--- a/src/routes/admin/estadistiques-acces/+page.svelte
+++ b/src/routes/admin/estadistiques-acces/+page.svelte
@@ -1,0 +1,459 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import Banner from '$lib/components/general/Banner.svelte';
+  import Loader from '$lib/components/general/Loader.svelte';
+  import { formatSupabaseError } from '$lib/ui/alerts';
+  import { initAdminPage } from '$lib/utils/adminPage';
+  import UsageChart from '$lib/components/admin/UsageChart.svelte';
+  import {
+    getPageViewTotals,
+    getSectionStats,
+    getDailyStats,
+    getTopPaths,
+    sectionLabel,
+    type PageViewTotals,
+    type SectionStat,
+    type DailyStat,
+    type TopPath
+  } from '$lib/api/pageViews';
+  import type { EChartsOption } from 'echarts';
+
+  let loading = true;
+  let error: string | null = null;
+
+  // Controls
+  const RANGES = [
+    { days: 7, label: '7 dies' },
+    { days: 30, label: '30 dies' },
+    { days: 90, label: '90 dies' },
+    { days: 365, label: '1 any' }
+  ];
+  let rangeDays = 30;
+  let excludeAdmin = true;
+
+  // Data
+  let totals: PageViewTotals = {
+    total_views: 0,
+    unique_visitors: 0,
+    authed_views: 0,
+    anon_views: 0
+  };
+  let sections: SectionStat[] = [];
+  let daily: DailyStat[] = [];
+  let topPaths: TopPath[] = [];
+
+  onMount(async () => {
+    const result = await initAdminPage(async () => {
+      await load();
+    });
+    loading = result.loading;
+    if (result.error) error = result.error;
+  });
+
+  function rangeBounds(days: number): { fromISO: string; toISO: string } {
+    const to = new Date();
+    const from = new Date(to.getTime() - days * 24 * 60 * 60 * 1000);
+    return { fromISO: from.toISOString(), toISO: to.toISOString() };
+  }
+
+  async function load() {
+    loading = true;
+    error = null;
+    try {
+      const { fromISO, toISO } = rangeBounds(rangeDays);
+      const opts = { fromISO, toISO, includeAdmin: !excludeAdmin };
+      const [t, s, d, p] = await Promise.all([
+        getPageViewTotals(opts),
+        getSectionStats(opts),
+        getDailyStats(opts),
+        getTopPaths({ ...opts, limit: 20 })
+      ]);
+      totals = t;
+      sections = s;
+      daily = d;
+      topPaths = p;
+    } catch (e) {
+      error = formatSupabaseError(e);
+    } finally {
+      loading = false;
+    }
+  }
+
+  function setRange(days: number) {
+    if (days === rangeDays) return;
+    rangeDays = days;
+    void load();
+  }
+
+  function toggleExcludeAdmin() {
+    excludeAdmin = !excludeAdmin;
+    void load();
+  }
+
+  // ── Derivats ────────────────────────────────────────────────────────────
+  $: pctAuthed =
+    totals.total_views > 0
+      ? Math.round((totals.authed_views / totals.total_views) * 100)
+      : 0;
+  $: topSection = sections.length > 0 ? sectionLabel(sections[0].section) : '—';
+  $: hasData = totals.total_views > 0;
+
+  function fmtNum(n: number): string {
+    return new Intl.NumberFormat('ca-ES').format(n);
+  }
+
+  // Omple els dies sense dades amb 0 perquè la línia temporal sigui contínua.
+  function fillDailyGaps(rows: DailyStat[], days: number): DailyStat[] {
+    const map = new Map(rows.map((r) => [r.day, r]));
+    const out: DailyStat[] = [];
+    const today = new Date();
+    for (let i = days - 1; i >= 0; i--) {
+      const d = new Date(today.getTime() - i * 24 * 60 * 60 * 1000);
+      const y = d.getFullYear();
+      const m = String(d.getMonth() + 1).padStart(2, '0');
+      const dd = String(d.getDate()).padStart(2, '0');
+      const key = `${y}-${m}-${dd}`;
+      out.push(map.get(key) ?? { day: key, views: 0, visitors: 0 });
+    }
+    return out;
+  }
+
+  function shortDay(iso: string): string {
+    const [y, m, d] = iso.split('-').map(Number);
+    return new Date(y, m - 1, d).toLocaleDateString('ca-ES', {
+      day: 'numeric',
+      month: 'short'
+    });
+  }
+
+  // ── Opcions ECharts ─────────────────────────────────────────────────────
+  $: filledDaily = fillDailyGaps(daily, rangeDays);
+
+  $: dailyOption = {
+    tooltip: { trigger: 'axis' },
+    legend: { data: ['Visites', 'Visitants únics'], top: 0 },
+    grid: { left: 48, right: 24, top: 36, bottom: 64 },
+    xAxis: {
+      type: 'category',
+      data: filledDaily.map((r) => shortDay(r.day)),
+      axisLabel: {
+        rotate: 45,
+        interval: Math.max(0, Math.floor(filledDaily.length / 12))
+      }
+    },
+    yAxis: { type: 'value', minInterval: 1 },
+    series: [
+      {
+        name: 'Visites',
+        type: 'line',
+        smooth: true,
+        showSymbol: false,
+        data: filledDaily.map((r) => r.views),
+        itemStyle: { color: '#1f4a99' },
+        areaStyle: { color: 'rgba(31,74,153,0.10)' }
+      },
+      {
+        name: 'Visitants únics',
+        type: 'line',
+        smooth: true,
+        showSymbol: false,
+        data: filledDaily.map((r) => r.visitors),
+        itemStyle: { color: '#1f7a3a' }
+      }
+    ]
+  } as EChartsOption;
+
+  $: sectionOption = {
+    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    grid: { left: 8, right: 24, top: 12, bottom: 12, containLabel: true },
+    xAxis: { type: 'value', minInterval: 1 },
+    yAxis: {
+      type: 'category',
+      data: [...sections].reverse().map((s) => sectionLabel(s.section)),
+      axisLabel: { fontSize: 13 }
+    },
+    series: [
+      {
+        name: 'Visites',
+        type: 'bar',
+        data: [...sections].reverse().map((s) => s.views),
+        itemStyle: { color: '#1f4a99' },
+        label: { show: true, position: 'right' }
+      }
+    ]
+  } as EChartsOption;
+</script>
+
+<svelte:head>
+  <title>Estadístiques d'accés</title>
+</svelte:head>
+
+<div class="st-root">
+  <header class="st-mast">
+    <div class="editorial-eyebrow">Administració · Ús de l'aplicació</div>
+    <h1 class="st-title">Estadístiques d'accés</h1>
+    <p class="st-sub">
+      Visites a les diferents seccions i pàgines de l'aplicació. Les dades són
+      <strong>agregades i anònimes</strong>: no es vincula cap visita a un soci concret.
+    </p>
+  </header>
+
+  <!-- Controls -->
+  <div class="st-controls">
+    <div class="st-range" role="group" aria-label="Període">
+      {#each RANGES as r (r.days)}
+        <button
+          type="button"
+          class="st-range-btn"
+          class:active={rangeDays === r.days}
+          on:click={() => setRange(r.days)}
+        >
+          {r.label}
+        </button>
+      {/each}
+    </div>
+    <label class="st-toggle">
+      <input type="checkbox" checked={excludeAdmin} on:change={toggleExcludeAdmin} />
+      <span>Excloure trànsit d'administradors</span>
+    </label>
+  </div>
+
+  {#if error}
+    <Banner type="error" message={error} />
+    <p class="st-hint">
+      Si el problema persisteix, comprova que la migració d'estadístiques s'ha aplicat
+      a la base de dades.
+    </p>
+  {:else if loading}
+    <Loader />
+  {:else if !hasData}
+    <div class="st-empty">
+      <p>Encara no s'ha registrat cap visita en aquest període.</p>
+      <p class="st-hint">
+        El registre comença a partir del desplegament d'aquesta funcionalitat; les dades
+        s'aniran acumulant a mesura que els usuaris naveguin per l'aplicació.
+      </p>
+    </div>
+  {:else}
+    <!-- KPIs -->
+    <div class="st-kpis">
+      <div class="st-kpi">
+        <div class="st-kpi-val tabular-nums">{fmtNum(totals.total_views)}</div>
+        <div class="st-kpi-lbl">Visites totals</div>
+      </div>
+      <div class="st-kpi">
+        <div class="st-kpi-val tabular-nums">{fmtNum(totals.unique_visitors)}</div>
+        <div class="st-kpi-lbl">Visitants únics</div>
+      </div>
+      <div class="st-kpi">
+        <div class="st-kpi-val tabular-nums">{pctAuthed}%</div>
+        <div class="st-kpi-lbl">Visites amb sessió iniciada</div>
+      </div>
+      <div class="st-kpi">
+        <div class="st-kpi-val">{topSection}</div>
+        <div class="st-kpi-lbl">Secció més visitada</div>
+      </div>
+    </div>
+
+    <!-- Evolució diària -->
+    <section class="st-block">
+      <h2 class="st-block-title">Evolució diària</h2>
+      <UsageChart option={dailyOption} height={320} />
+    </section>
+
+    <!-- Visites per secció -->
+    <section class="st-block">
+      <h2 class="st-block-title">Visites per secció</h2>
+      <UsageChart option={sectionOption} height={Math.max(220, sections.length * 46)} />
+    </section>
+
+    <!-- Pàgines més vistes -->
+    <section class="st-block">
+      <h2 class="st-block-title">Pàgines més vistes</h2>
+      <div class="st-table-wrap">
+        <table class="st-table">
+          <thead>
+            <tr>
+              <th>Pàgina</th>
+              <th>Secció</th>
+              <th class="num">Visites</th>
+              <th class="num">Visitants</th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each topPaths as p (p.path)}
+              <tr>
+                <td class="st-path">{p.path}</td>
+                <td>{sectionLabel(p.section)}</td>
+                <td class="num tabular-nums">{fmtNum(p.views)}</td>
+                <td class="num tabular-nums">{fmtNum(p.visitors)}</td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  {/if}
+</div>
+
+<style>
+  .st-root {
+    max-width: 1180px;
+    margin: 0 auto;
+    padding: 1.75rem 1.25rem 4rem;
+    font-family: var(--font-sans, sans-serif);
+    color: var(--ink, #1a1814);
+  }
+  .st-mast {
+    margin-bottom: 1.5rem;
+    padding-bottom: 1.1rem;
+    border-bottom: 2px solid var(--ink, #1a1814);
+  }
+  .editorial-eyebrow {
+    font-size: 0.625rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    color: var(--ink-3, #807a72);
+  }
+  .st-title {
+    margin: 0.4rem 0 0.4rem;
+    font-size: clamp(1.75rem, 2.4vw, 2.4rem);
+    font-weight: 800;
+    letter-spacing: -0.022em;
+    line-height: 1.1;
+  }
+  .st-sub {
+    margin: 0;
+    font-size: 0.9375rem;
+    color: var(--ink-2, #4a443e);
+    max-width: 64ch;
+  }
+
+  .st-controls {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+  }
+  .st-range {
+    display: inline-flex;
+    border: 1px solid var(--rule-strong, #b8b3a8);
+  }
+  .st-range-btn {
+    appearance: none;
+    border: none;
+    background: var(--paper-elevated, #fff);
+    color: var(--ink-2, #4a443e);
+    padding: 0.5rem 0.9rem;
+    font-size: 0.875rem;
+    font-weight: 600;
+    cursor: pointer;
+    border-right: 1px solid var(--rule, #e6e3dc);
+    min-height: 44px;
+  }
+  .st-range-btn:last-child {
+    border-right: none;
+  }
+  .st-range-btn.active {
+    background: var(--ink, #1a1814);
+    color: var(--paper, #fbfaf6);
+  }
+  .st-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.875rem;
+    color: var(--ink-2, #4a443e);
+    cursor: pointer;
+  }
+  .st-toggle input {
+    width: 18px;
+    height: 18px;
+  }
+
+  .st-kpis {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1rem;
+    margin-bottom: 2rem;
+  }
+  .st-kpi {
+    background: var(--paper-elevated, #fff);
+    border: 1px solid var(--rule, #e6e3dc);
+    border-left: 3px solid var(--blue, #1f4a99);
+    padding: 1rem 1.1rem;
+  }
+  .st-kpi-val {
+    font-size: 1.875rem;
+    font-weight: 800;
+    line-height: 1.1;
+    letter-spacing: -0.02em;
+  }
+  .st-kpi-lbl {
+    margin-top: 0.25rem;
+    font-size: 0.8125rem;
+    color: var(--ink-3, #807a72);
+    font-weight: 600;
+  }
+
+  .st-block {
+    margin-bottom: 2.25rem;
+  }
+  .st-block-title {
+    font-size: 1.05rem;
+    font-weight: 700;
+    margin: 0 0 0.75rem;
+    color: var(--ink, #1a1814);
+  }
+
+  .st-table-wrap {
+    border: 1px solid var(--rule, #e6e3dc);
+    background: var(--paper-elevated, #fff);
+    overflow-x: auto;
+  }
+  .st-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.875rem;
+  }
+  .st-table th,
+  .st-table td {
+    text-align: left;
+    padding: 0.6rem 0.85rem;
+    border-bottom: 1px solid var(--rule, #e6e3dc);
+  }
+  .st-table thead th {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--ink-3, #807a72);
+    background: var(--paper, #fbfaf6);
+  }
+  .st-table tbody tr:last-child td {
+    border-bottom: none;
+  }
+  .st-table .num {
+    text-align: right;
+  }
+  .st-path {
+    font-family: var(--font-mono, ui-monospace, monospace);
+    color: var(--ink-2, #4a443e);
+    word-break: break-all;
+  }
+
+  .st-empty {
+    background: var(--paper-elevated, #fff);
+    border: 1px solid var(--rule, #e6e3dc);
+    padding: 2.5rem 1.5rem;
+    text-align: center;
+    color: var(--ink-2, #4a443e);
+  }
+  .st-hint {
+    margin-top: 0.5rem;
+    font-size: 0.8125rem;
+    color: var(--ink-3, #807a72);
+  }
+</style>

--- a/supabase/migrations/20260617000000_page_views_analytics.sql
+++ b/supabase/migrations/20260617000000_page_views_analytics.sql
@@ -1,0 +1,234 @@
+-- ============================================================================
+-- Migració: Estadístiques d'accés (visites de pàgina) per a administradors
+-- Data: 2026-06-17
+--
+-- Objectiu: registrar de manera AGREGADA i ANÒNIMA les visites a les diferents
+-- seccions/pàgines de l'aplicació, perquè els admins puguin veure estadístiques
+-- d'ús (visites per secció, evolució diària, pàgines més vistes).
+--
+-- Decisions de privadesa (acordades amb l'usuari):
+--   * NO es desa cap identitat d'usuari (ni email, ni numero_soci, ni auth uid).
+--   * Només es desen: secció derivada, path normalitzat, dos flags booleans
+--     (is_authenticated / is_admin) i un visitor_id aleatori per navegador
+--     (generat al client, guardat a localStorage) per estimar visitants únics
+--     sense identificar ningú.
+--   * Es compten també les visites de visitants no loggats (anònims).
+--
+-- Arquitectura:
+--   * Escriptura: NOMÉS via la funció SECURITY DEFINER public.log_page_view().
+--     Els flags is_authenticated/is_admin es deriven al servidor (no es confia
+--     en el client). Es concedeix EXECUTE a anon i authenticated.
+--   * Lectura: la taula té RLS amb SELECT només per a admins. L'agregació es fa
+--     amb funcions SQL SECURITY INVOKER (respecten la RLS de qui les crida), de
+--     manera que retornen poques files i no topen amb el límit max_rows=1000 de
+--     PostgREST.
+-- ============================================================================
+
+-- ─── Taula ───────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.page_views (
+  id               BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  path             TEXT NOT NULL,
+  section          TEXT NOT NULL,
+  is_authenticated BOOLEAN NOT NULL DEFAULT false,
+  is_admin         BOOLEAN NOT NULL DEFAULT false,
+  visitor_id       UUID
+);
+
+COMMENT ON TABLE public.page_views IS
+  'Registre agregat i anònim de visites de pàgina per a estadístiques d''ús (admin). No desa cap identitat d''usuari.';
+
+CREATE INDEX IF NOT EXISTS idx_page_views_created_at
+  ON public.page_views (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_page_views_section_created_at
+  ON public.page_views (section, created_at DESC);
+
+-- ─── RLS: lectura només admins; escriptura directa bloquejada ─────────────────
+
+ALTER TABLE public.page_views ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS page_views_admin_select ON public.page_views;
+CREATE POLICY page_views_admin_select ON public.page_views
+  FOR SELECT
+  TO authenticated
+  USING ((SELECT public.is_admin_by_email()));
+
+-- Ningú escriu directament: només via log_page_view() (SECURITY DEFINER).
+REVOKE INSERT, UPDATE, DELETE ON public.page_views FROM anon, authenticated;
+
+-- ─── Funció d'escriptura ──────────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.log_page_view(
+  p_path TEXT,
+  p_visitor_id UUID DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+DECLARE
+  v_uid     UUID := auth.uid();
+  v_email   TEXT;
+  v_is_admin BOOLEAN := false;
+  v_path    TEXT;
+  v_section TEXT;
+BEGIN
+  IF p_path IS NULL OR length(p_path) = 0 THEN
+    RETURN;
+  END IF;
+
+  -- Normalitza el path: límit de longitud i col·lapsa identificadors dinàmics
+  -- (UUIDs i ids numèrics) perquè les pàgines amb paràmetre agrupin bé.
+  v_path := left(p_path, 300);
+  v_path := regexp_replace(
+    v_path,
+    '/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}',
+    '/:id', 'g'
+  );
+  v_path := regexp_replace(v_path, '/[0-9]+', '/:id', 'g');
+
+  v_section := CASE
+    WHEN v_path = '/'                            THEN 'inici'
+    WHEN v_path LIKE '/general%'                 THEN 'general'
+    WHEN v_path LIKE '/campionats-socials%'      THEN 'campionats-socials'
+    WHEN v_path LIKE '/campionat-continu%'       THEN 'campionat-continu'
+    WHEN v_path LIKE '/handicap%'                THEN 'handicap'
+    WHEN v_path LIKE '/admin%'                   THEN 'admin'
+    WHEN v_path LIKE '/jugador%'                 THEN 'jugador'
+    ELSE 'altres'
+  END;
+
+  IF v_uid IS NOT NULL THEN
+    SELECT u.email INTO v_email FROM auth.users u WHERE u.id = v_uid;
+    IF v_email IS NOT NULL THEN
+      v_is_admin := EXISTS (SELECT 1 FROM public.admins a WHERE a.email = v_email);
+    END IF;
+  END IF;
+
+  INSERT INTO public.page_views (path, section, is_authenticated, is_admin, visitor_id)
+  VALUES (v_path, v_section, v_uid IS NOT NULL, v_is_admin, p_visitor_id);
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.log_page_view(TEXT, UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.log_page_view(TEXT, UUID) TO anon, authenticated;
+
+-- ─── Funcions d'agregació (SECURITY INVOKER → respecten la RLS de la taula) ──
+
+CREATE OR REPLACE FUNCTION public.get_page_view_totals(
+  p_from timestamptz,
+  p_to timestamptz,
+  p_include_admin boolean DEFAULT false
+)
+RETURNS TABLE (
+  total_views     bigint,
+  unique_visitors bigint,
+  authed_views    bigint,
+  anon_views      bigint
+)
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT
+    count(*)::bigint,
+    count(DISTINCT pv.visitor_id)::bigint,
+    count(*) FILTER (WHERE pv.is_authenticated)::bigint,
+    count(*) FILTER (WHERE NOT pv.is_authenticated)::bigint
+  FROM public.page_views pv
+  WHERE pv.created_at >= p_from
+    AND pv.created_at <  p_to
+    AND (p_include_admin OR NOT pv.is_admin);
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_page_view_section_stats(
+  p_from timestamptz,
+  p_to timestamptz,
+  p_include_admin boolean DEFAULT false
+)
+RETURNS TABLE (
+  section      text,
+  views        bigint,
+  visitors     bigint,
+  authed_views bigint
+)
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT
+    pv.section,
+    count(*)::bigint,
+    count(DISTINCT pv.visitor_id)::bigint,
+    count(*) FILTER (WHERE pv.is_authenticated)::bigint
+  FROM public.page_views pv
+  WHERE pv.created_at >= p_from
+    AND pv.created_at <  p_to
+    AND (p_include_admin OR NOT pv.is_admin)
+  GROUP BY pv.section
+  ORDER BY count(*) DESC;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_page_view_daily(
+  p_from timestamptz,
+  p_to timestamptz,
+  p_include_admin boolean DEFAULT false
+)
+RETURNS TABLE (
+  day      date,
+  views    bigint,
+  visitors bigint
+)
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT
+    (pv.created_at AT TIME ZONE 'Europe/Madrid')::date AS day,
+    count(*)::bigint,
+    count(DISTINCT pv.visitor_id)::bigint
+  FROM public.page_views pv
+  WHERE pv.created_at >= p_from
+    AND pv.created_at <  p_to
+    AND (p_include_admin OR NOT pv.is_admin)
+  GROUP BY (pv.created_at AT TIME ZONE 'Europe/Madrid')::date
+  ORDER BY 1;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_page_view_top_paths(
+  p_from timestamptz,
+  p_to timestamptz,
+  p_include_admin boolean DEFAULT false,
+  p_limit int DEFAULT 20
+)
+RETURNS TABLE (
+  path     text,
+  section  text,
+  views    bigint,
+  visitors bigint
+)
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT
+    pv.path,
+    pv.section,
+    count(*)::bigint,
+    count(DISTINCT pv.visitor_id)::bigint
+  FROM public.page_views pv
+  WHERE pv.created_at >= p_from
+    AND pv.created_at <  p_to
+    AND (p_include_admin OR NOT pv.is_admin)
+  GROUP BY pv.path, pv.section
+  ORDER BY count(*) DESC
+  LIMIT GREATEST(p_limit, 1);
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_page_view_totals(timestamptz, timestamptz, boolean) FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.get_page_view_section_stats(timestamptz, timestamptz, boolean) FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.get_page_view_daily(timestamptz, timestamptz, boolean) FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.get_page_view_top_paths(timestamptz, timestamptz, boolean, int) FROM PUBLIC, anon;
+
+GRANT EXECUTE ON FUNCTION public.get_page_view_totals(timestamptz, timestamptz, boolean) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_page_view_section_stats(timestamptz, timestamptz, boolean) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_page_view_daily(timestamptz, timestamptz, boolean) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_page_view_top_paths(timestamptz, timestamptz, boolean, int) TO authenticated;


### PR DESCRIPTION
## Resum

Afegeix estadístiques d'accés (visites de pàgina) per a administradors, **agregades i anònimes** (no es vincula cap visita a un soci concret; es compten també els anònims).

## Què inclou

- **Migració `page_views`**: taula amb RLS (SELECT només admins), funció d'escriptura `log_page_view()` (SECURITY DEFINER — deriva `is_authenticated`/`is_admin` al servidor, no desa cap identitat) i 4 funcions d'agregació SECURITY INVOKER (totals, per secció, diari, top paths) que respecten la RLS i eviten el límit `max_rows`.
- **Tracking client** (`page-view-tracking.ts`): hook `afterNavigate` al layout arrel, `visitor_id` anònim a localStorage, fire-and-forget, **no registra en dev** i s'auto-deshabilita si falla repetidament (p. ex. si la migració encara no és a prod).
- **Pàgina `/admin/estadistiques-acces`**: KPIs (visites, visitants únics, % loggats, secció top), evolució diària i visites per secció (ECharts), taula de pàgines més vistes; filtre de període (7/30/90/365 dies) i toggle per excloure trànsit d'admins.
- Enllaços al dashboard admin i a `NavEditorial`.

## ⚠️ Pas manual de desplegament

La **migració SQL s'ha d'aplicar a Supabase prod** (no es pot fer des de l'entorn de build). Fins que no s'apliqui, la pàgina mostra un avís i el tracking s'auto-deshabilita.

## Verificació

- `npm run check`: 0 errors, 0 warnings
- `npm run build`: OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)