### PR TITLE
fix(auth): evita el deadlock de hydrateSession a onAuthStateChange

### DIFF
--- a/src/lib/utils/auth-client.ts
+++ b/src/lib/utils/auth-client.ts
@@ -130,6 +130,24 @@ export async function hydrateSession() {
   return Promise.race([hydrationPromise, timeoutPromise]);
 }
 
+/**
+ * Programa una hidratació de sessió FORA del callback d'onAuthStateChange.
+ *
+ * supabase-js invoca el callback d'onAuthStateChange mentre té agafat el lock
+ * intern d'auth (navigator.locks). Si cridem `hydrateSession()` —que fa
+ * `getSession()`— síncronament dins del callback, `getSession()` intenta agafar
+ * el MATEIX lock i es produeix un deadlock que només es desbloqueja amb el
+ * timeout de 20s. Diferir-ho amb `setTimeout(0)` permet que el callback retorni
+ * i s'alliberi el lock abans de tornar-lo a agafar.
+ */
+function scheduleHydrate() {
+  setTimeout(() => {
+    hydrateSession().catch((e) =>
+      console.error('Deferred hydrateSession failed (keeping current state):', e)
+    );
+  }, 0);
+}
+
 export function initAuthClient() {
   if (initialized) return;
   initialized = true;
@@ -145,8 +163,10 @@ export function initAuthClient() {
 
     try {
       if (event === 'SIGNED_IN') {
-        // Només hidratar en SIGNED_IN, no en TOKEN_REFRESHED per evitar loops
-        await hydrateSession();
+        // Només hidratar en SIGNED_IN, no en TOKEN_REFRESHED per evitar loops.
+        // Diferit fora del callback per no fer deadlock amb el lock d'auth
+        // (vegeu scheduleHydrate).
+        scheduleHydrate();
       } else if (event === 'TOKEN_REFRESHED') {
         // Per TOKEN_REFRESHED, només actualitzar el token sense recarregar tot
         console.log('Token refreshed - updating token only');
@@ -166,7 +186,7 @@ export function initAuthClient() {
         console.log('Explicit sign out detected');
         authState.set({ status: 'anonymous', session: null, user: null });
       } else if (event === 'USER_UPDATED') {
-        await hydrateSession();
+        scheduleHydrate();
       }
       // Ignorar altres events per evitar logouts no desitjats
     } catch (error) {


### PR DESCRIPTION
## Problema
A producció apareixien penjades repetides de 20s: `[auth-client] hydrateSession timeout after 20s - keeping current state`, disparades en cada *visibility change* de la pestanya (traça: `_onVisibilityChanged → _acquireLock → _recoverAndRefresh → _notifyAllSubscribers → callback`).

## Causa
Deadlock clàssic de supabase-js: el callback d'`onAuthStateChange` s'invoca **amb el lock d'auth agafat**. El callback feia `await hydrateSession()`, que crida `supabase.auth.getSession()` → intenta agafar el **mateix lock** → s'espera fins al timeout de 20s.

## Fix
Diferir la hidratació fora del callback amb `setTimeout(0)` (`scheduleHydrate()`), de manera que el callback retorna i s'allibera el lock abans de tornar-lo a agafar. És el patró recomanat per Supabase (no cridar mètodes d'auth síncronament dins d'`onAuthStateChange`).

Afecta només les branques `SIGNED_IN` i `USER_UPDATED`. `TOKEN_REFRESHED`/`SIGNED_OUT` ja feien servir l'argument `session` sense cridar `getSession()`.

`npm run check`: 0 errors, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)