### PR TITLE
fix(analytics): registra el tracking de visites durant la init del component

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -19,6 +19,15 @@
   let showInscripcio = false;
   let showAccessibilityModal = false;
 
+  // IMPORTANT: aquestes dues funcions registren `afterNavigate`, que SvelteKit
+  // implementa amb un `onMount` intern. Per això s'han de cridar durant la
+  // INICIALITZACIÓ del component, NO dins d'un altre `onMount`: si es criden des
+  // d'`onMount`, l'`onMount` intern d'`afterNavigate` ja no s'executa mai i el
+  // callback de navegació no es registra (el tracking de visites i la gestió de
+  // focus quedaven silenciosament inactius).
+  setupFocusManagement();
+  setupPageViewTracking();
+
   type SessionUser = { email: string | null } | null;
 
   async function refreshInscripcioVisibility(u: SessionUser) {
@@ -147,11 +156,8 @@
     // Inicialitza sistema de notificacions push
     initializeNotifications();
 
-    // Configura gestió del focus per accessibilitat
-    setupFocusManagement();
-
-    // Registre anònim de visites de pàgina (estadístiques d'ús per a admins)
-    setupPageViewTracking();
+    // (setupFocusManagement i setupPageViewTracking es criden durant la
+    //  inicialització del component, no aquí — vegeu el comentari de dalt.)
 
     // Escoltar actualitzacions de PWA
     window.addEventListener('pwa-update-available', (event) => {


### PR DESCRIPTION
## Problema
La taula `page_views` a prod estava buida: no es registrava cap visita.

## Causa
`afterNavigate` de SvelteKit s'implementa amb un `onMount` intern (`add_navigation_callback`). Per tant **s'ha de cridar durant la inicialització del component**. `setupPageViewTracking()` (i `setupFocusManagement()`) es cridaven DINS de l'`onMount` del layout → l'`onMount` intern d'`afterNavigate` ja no s'executava mai → el callback de navegació no es registrava i no es desava cap visita. (`setupFocusManagement` patia el mateix bug latent: la gestió de focus d'accessibilitat també estava inactiva.)

## Fix
Es mouen les dues crides a l'scope d'inicialització del component (top-level del `<script>`), fora d'`onMount`.

`npm run check`: 0/0 · `npm run build`: OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)