### PR TITLE
Mostra l'origen del contrincant pendent a les partides d'hàndicap

### DIFF
--- a/src/lib/components/general/MyUpcomingMatchesWidget.svelte
+++ b/src/lib/components/general/MyUpcomingMatchesWidget.svelte
@@ -13,6 +13,7 @@
   import { supabase } from '$lib/supabaseClient';
   import { mySociNumero } from '$lib/stores/mySoci';
   import { formatarNomJugador } from '$lib/utils/playerUtils';
+  import { loadHandicapCalendarLabels, type HandicapCalendarLabels } from '$lib/utils/handicap-calendar-labels';
 
   /** Nombre màxim de partides a mostrar. */
   export let limit = 5;
@@ -35,10 +36,13 @@
     j2_nom?: string | null;
     j2_cognoms?: string | null;
     event_nom?: string | null;
+    event_tipus?: string | null;
     categoria_nom?: string | null;
   };
 
   let matches: Match[] = [];
+  // Etiquetes d'hàndicap (origen dels slots pendents), per id de calendari_partida.
+  let handicapLabels = new Map<string, HandicapCalendarLabels>();
   let loading = false;
 
   // Resol el soci_numero efectiu: la prop si es passa, sinó l'usuari loggat
@@ -92,7 +96,7 @@
       const [{ data: socis }, { data: events }, { data: cats }] = await Promise.all([
         supabase.from('socis').select('numero_soci, nom, cognoms').in('numero_soci', Array.from(sociIds)),
         eventIds.size
-          ? supabase.from('events').select('id, nom').in('id', Array.from(eventIds))
+          ? supabase.from('events').select('id, nom, tipus_competicio').in('id', Array.from(eventIds))
           : Promise.resolve({ data: [] as any[] }),
         categoryIds.size
           ? supabase.from('categories').select('id, nom').in('id', Array.from(categoryIds))
@@ -102,9 +106,20 @@
       const sociMap = new Map<number, { nom: string; cognoms: string }>();
       (socis ?? []).forEach((s: any) => sociMap.set(s.numero_soci, { nom: s.nom, cognoms: s.cognoms }));
       const eventMap = new Map<string, string>();
-      (events ?? []).forEach((e: any) => eventMap.set(e.id, e.nom));
+      const eventTipusMap = new Map<string, string>();
+      (events ?? []).forEach((e: any) => {
+        eventMap.set(e.id, e.nom);
+        if (e.tipus_competicio) eventTipusMap.set(e.id, e.tipus_competicio);
+      });
       const catMap = new Map<string, string>();
       (cats ?? []).forEach((c: any) => catMap.set(c.id, c.nom));
+
+      // Hàndicap: resoldre l'origen dels contrincants encara per determinar
+      // ("Guanyador W1.1") en comptes de deixar el nom en blanc.
+      const hcapEventIds = Array.from(eventIds).filter((id) => eventTipusMap.get(id) === 'handicap');
+      handicapLabels = hcapEventIds.length > 0
+        ? await loadHandicapCalendarLabels(supabase, hcapEventIds)
+        : new Map();
 
       matches = rows.map((m) => ({
         ...m,
@@ -113,6 +128,7 @@
         j2_nom: sociMap.get(m.jugador2_soci_numero)?.nom ?? null,
         j2_cognoms: sociMap.get(m.jugador2_soci_numero)?.cognoms ?? null,
         event_nom: m.event_id ? eventMap.get(m.event_id) ?? null : null,
+        event_tipus: m.event_id ? eventTipusMap.get(m.event_id) ?? null : null,
         categoria_nom: m.categoria_id ? catMap.get(m.categoria_id) ?? null : null
       }));
     } finally {
@@ -131,11 +147,22 @@
     });
   }
 
-  function opponentName(m: Match, soci: number): string {
+  /**
+   * Nom del contrincant. Per a l'hàndicap, si el contrincant encara no està
+   * definit, retorna el seu origen ("Guanyador W1.1") i marca resolved=false.
+   */
+  function opponentInfo(m: Match, soci: number): { name: string; resolved: boolean } {
     const isPlayer1 = m.jugador1_soci_numero === soci;
+    const labels = handicapLabels.get(m.id);
+    if (labels) {
+      const op = isPlayer1
+        ? { name: labels.player2, resolved: labels.player2Resolved }
+        : { name: labels.player1, resolved: labels.player1Resolved };
+      if (op.name) return op;
+    }
     const opNom = isPlayer1 ? m.j2_nom : m.j1_nom;
     const opCog = isPlayer1 ? m.j2_cognoms : m.j1_cognoms;
-    return formatarNomJugador(`${opNom ?? ''} ${opCog ?? ''}`.trim());
+    return { name: formatarNomJugador(`${opNom ?? ''} ${opCog ?? ''}`.trim()), resolved: true };
   }
 </script>
 
@@ -147,6 +174,7 @@
     </header>
     <ol class="ump-list">
       {#each matches as m (m.id)}
+        {@const op = opponentInfo(m, effectiveSoci)}
         <li class="ump-row">
           <div class="ump-date">
             <div class="ump-date-day tabular-nums">{formatDate(m.data_programada)}</div>
@@ -156,7 +184,7 @@
           </div>
           <div class="ump-info">
             <div class="ump-opponent">
-              vs <strong>{opponentName(m, effectiveSoci)}</strong>
+              vs <strong class:pending={!op.resolved}>{op.name}</strong>
             </div>
             <div class="ump-meta">
               {#if m.event_nom}{m.event_nom}{/if}
@@ -227,6 +255,12 @@
     color: var(--ink-2, #4a443e);
   }
   .ump-opponent strong { color: var(--ink, #1a1814); }
+  /* Contrincant encara per determinar (hàndicap): origen en cursiva. */
+  .ump-opponent strong.pending {
+    font-style: italic;
+    font-weight: 600;
+    color: var(--ink-2, #4a443e);
+  }
   .ump-meta {
     margin-top: 0.2rem;
     font-size: 0.8125rem;

--- a/src/lib/stores/calendar.ts
+++ b/src/lib/stores/calendar.ts
@@ -2,6 +2,7 @@
 import { writable, derived, get } from 'svelte/store';
 import { supabase } from '$lib/supabaseClient';
 import { user } from '$lib/stores/auth';
+import { loadHandicapCalendarLabels } from '$lib/utils/handicap-calendar-labels';
 
 export type CalendarView = 'month' | 'week';
 
@@ -36,6 +37,10 @@ export type PartidaCalendari = {
   jugador2_nom: string;
   jugador1?: any; // Dades originals del jugador 1
   jugador2?: any; // Dades originals del jugador 2
+  // Etiqueta de visualització ja resolta (hàndicap): nom real o origen del
+  // slot pendent ("Guanyador W1.1"). Si és null, es formata des de jugadorN.
+  jugador1_label?: string | null;
+  jugador2_label?: string | null;
   jugador1_soci_numero: number | null;
   jugador2_soci_numero: number | null;
   data_programada: string;
@@ -152,8 +157,10 @@ export const calendarEvents = derived(
           return 'Jugador desconegut';
         };
         
-        const jugador1Format = formatPlayerName(partida.jugador1);
-        const jugador2Format = formatPlayerName(partida.jugador2);
+        // Hàndicap: si el slot encara no està resolt, `jugadorN_label` porta
+        // l'origen ("Guanyador W1.1") en comptes de quedar en blanc/Desconegut.
+        const jugador1Format = partida.jugador1_label ?? formatPlayerName(partida.jugador1);
+        const jugador2Format = partida.jugador2_label ?? formatPlayerName(partida.jugador2);
 
         const isHandicap = partida.event_tipus === 'handicap';
         // L'hàndicap no té categoria; només l'afegim a la descripció si n'hi ha.
@@ -471,6 +478,32 @@ export async function loadPartidesCalendari(setLoading: boolean = true): Promise
         observacions_junta: item.observacions_junta
       };
     });
+
+    // Hàndicap: resoldre l'origen dels slots pendents ("Guanyador W1.1", etc.)
+    // perquè les partides amb contrincants encara per determinar es vegin amb
+    // informació útil en comptes de "Jugador desconegut".
+    const hcapEventIds = [
+      ...new Set(
+        data
+          .filter((item: any) => (item.events as any)?.tipus_competicio === 'handicap')
+          .map((item: any) => item.event_id as string)
+          .filter(Boolean)
+      )
+    ] as string[];
+    if (hcapEventIds.length > 0) {
+      try {
+        const labelMap = await loadHandicapCalendarLabels(supabase, hcapEventIds);
+        for (const p of partides) {
+          if (p.event_tipus !== 'handicap') continue;
+          const lbl = labelMap.get(p.id);
+          if (!lbl) continue;
+          p.jugador1_label = lbl.player1;
+          p.jugador2_label = lbl.player2;
+        }
+      } catch (e) {
+        console.warn('⚠️ No s\'han pogut resoldre les etiquetes d\'hàndicap:', e);
+      }
+    }
 
     console.log('✅ Successfully processed matches:', partides.length);
     partidesCalendari.set(partides);

--- a/src/lib/utils/handicap-calendar-labels.ts
+++ b/src/lib/utils/handicap-calendar-labels.ts
@@ -1,0 +1,131 @@
+/**
+ * Etiquetes dels jugadors d'una partida d'hàndicap programada al calendari
+ * general (taula `calendari_partides`).
+ *
+ * Problema que resol: quan una partida d'hàndicap es programa amb data
+ * orientativa abans de conèixer els dos contrincants, les columnes
+ * `jugador1_soci_numero` / `jugador2_soci_numero` de `calendari_partides`
+ * queden a NULL per al slot encara no resolt. Els consumidors del calendari
+ * general (home, /general/calendari, widget de properes partides) mostraven
+ * llavors "Desconegut" o el nom en blanc.
+ *
+ * Aquesta utilitat replica la lògica de `/handicap/calendari` per resoldre
+ * l'origen del slot pendent ("Guanyador W1.1", "Perdedor L2.3" o, si no es pot
+ * determinar, "Per determinar") i retorna un mapa
+ * `calendari_partida_id → etiquetes dels dos jugadors`.
+ *
+ * L'alineació slot1↔jugador1 / slot2↔jugador2 és la que escriu
+ * `handicap-schedule-persist.ts` en sincronitzar el bracket amb el calendari.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { buildMatchCodeMap, buildSlotSourceMap } from '$lib/utils/handicap-types';
+import { formatarNomJugadorParts } from '$lib/utils/playerUtils';
+
+export interface HandicapCalendarLabels {
+	/** Nom real del jugador 1 si està resolt; si no, l'origen ("Guanyador W1.1"). */
+	player1: string;
+	/** Nom real del jugador 2 si està resolt; si no, l'origen ("Perdedor L2.3"). */
+	player2: string;
+	/** True si el slot 1 té un participant real assignat. */
+	player1Resolved: boolean;
+	/** True si el slot 2 té un participant real assignat. */
+	player2Resolved: boolean;
+	/** True només quan els dos jugadors són reals (data definitiva). */
+	playersResolved: boolean;
+}
+
+/**
+ * Donat un conjunt d'events d'hàndicap, retorna un mapa
+ * `calendari_partida_id → HandicapCalendarLabels`. Els slots no resolts es
+ * mostren amb el seu origen en comptes de quedar buits.
+ *
+ * Retorna un mapa buit si no hi ha cap event d'hàndicap o cap partida lligada
+ * al calendari.
+ */
+export async function loadHandicapCalendarLabels(
+	client: SupabaseClient,
+	eventIds: string[]
+): Promise<Map<string, HandicapCalendarLabels>> {
+	const out = new Map<string, HandicapCalendarLabels>();
+	const ids = [...new Set(eventIds.filter(Boolean))];
+	if (ids.length === 0) return out;
+
+	const { data: rawMatches } = await client
+		.from('handicap_matches')
+		.select(
+			'id, slot1_id, slot2_id, calendari_partida_id, winner_slot_dest_id, loser_slot_dest_id'
+		)
+		.in('event_id', ids)
+		.neq('estat', 'bye')
+		.not('calendari_partida_id', 'is', null);
+
+	if (!rawMatches || rawMatches.length === 0) return out;
+
+	const slotIds = rawMatches.flatMap((m: any) => [m.slot1_id, m.slot2_id]).filter(Boolean);
+	const { data: slots } = await client
+		.from('handicap_bracket_slots')
+		.select('id, bracket_type, ronda, posicio, participant_id')
+		.in('id', slotIds);
+	const slotMap = new Map((slots ?? []).map((s: any) => [s.id as string, s]));
+
+	// Noms reals dels participants ja resolts (FK directe soci_numero → socis).
+	const partIds = [
+		...new Set(
+			(slots ?? [])
+				.filter((s: any) => s.participant_id)
+				.map((s: any) => s.participant_id as string)
+		)
+	];
+	const nameMap = new Map<string, string>();
+	if (partIds.length > 0) {
+		const { data: parts } = await client
+			.from('handicap_participants')
+			.select('id, socis!handicap_participants_soci_numero_fkey(nom, cognoms)')
+			.in('id', partIds);
+		for (const p of parts ?? []) {
+			const s = Array.isArray((p as any).socis) ? (p as any).socis[0] : (p as any).socis;
+			nameMap.set((p as any).id as string, s ? formatarNomJugadorParts(s.nom, s.cognoms) || '?' : '?');
+		}
+	}
+
+	// Codis de match (W1.1, L2.3, GF1) + origen de cada slot pendent.
+	const codeInputs = rawMatches.map((m: any) => {
+		const s1: any = slotMap.get(m.slot1_id);
+		return {
+			id: m.id as string,
+			bracket_type: (s1?.bracket_type ?? 'winners') as string,
+			ronda: (s1?.ronda ?? 1) as number,
+			matchPos: s1 ? Math.ceil((s1.posicio as number) / 2) : 0
+		};
+	});
+	const codeMap = buildMatchCodeMap(codeInputs);
+	const slotSourceMap = buildSlotSourceMap(
+		rawMatches.map((m: any) => ({
+			id: m.id as string,
+			winner_slot_dest_id: m.winner_slot_dest_id as string | null,
+			loser_slot_dest_id: m.loser_slot_dest_id as string | null
+		})),
+		codeMap
+	);
+	const sourceLabel = (slotId: string): string => {
+		const src = slotSourceMap.get(slotId);
+		return src ? `${src.role} ${src.code}` : 'Per determinar';
+	};
+
+	for (const m of rawMatches as any[]) {
+		const s1: any = slotMap.get(m.slot1_id);
+		const s2: any = slotMap.get(m.slot2_id);
+		if (!s1 || !s2) continue;
+		const p1Resolved = !!s1.participant_id;
+		const p2Resolved = !!s2.participant_id;
+		out.set(m.calendari_partida_id as string, {
+			player1: p1Resolved ? nameMap.get(s1.participant_id) ?? '?' : sourceLabel(s1.id),
+			player2: p2Resolved ? nameMap.get(s2.participant_id) ?? '?' : sourceLabel(s2.id),
+			player1Resolved: p1Resolved,
+			player2Resolved: p2Resolved,
+			playersResolved: p1Resolved && p2Resolved
+		});
+	}
+	return out;
+}

--- a/src/routes/handicap/+page.svelte
+++ b/src/routes/handicap/+page.svelte
@@ -178,9 +178,11 @@
 				return { name: src ? `${src.role} ${src.code}` : 'Per determinar', resolved: false };
 			};
 
-			// Pròximes 3 programades
+			// Pròximes partides: incloem també les 'pendent' que ja tenen data
+			// orientativa (calendari_partida_id), perquè es vegin amb l'origen del
+			// contrincant ("Guanyador W1.1") en comptes d'amagar-se fins a resoldre's.
 			const programades = (matchStats as any[])
-				.filter((m) => m.estat === 'programada' && m.calendari_partida_id)
+				.filter((m) => (m.estat === 'programada' || m.estat === 'pendent') && m.calendari_partida_id)
 				.map((m) => {
 					const s1 = slotMap.get(m.slot1_id);
 					const s2 = slotMap.get(m.slot2_id);
@@ -205,10 +207,14 @@
 				const db = (b.data ?? '') + (b.hora ?? '');
 				return da.localeCompare(db);
 			});
-			// Pròximes partides: tots els partits dels 2 propers dies amb partides programades
+			// Pròximes partides: tots els partits dels 2 propers dies amb partides
+			// programades (descartem dates passades, sobretot ara que incloem
+			// pre-reserves 'pendent' que podrien tenir dates orientatives velles).
+			const now = new Date();
+			const todayYmd = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
 			const distinctDays: string[] = [];
 			for (const m of programades) {
-				if (m.data && !distinctDays.includes(m.data)) {
+				if (m.data && m.data >= todayYmd && !distinctDays.includes(m.data)) {
 					distinctDays.push(m.data);
 					if (distinctDays.length === 2) break;
 				}


### PR DESCRIPTION
## Resum

Les partides d'hàndicap amb contrincants **encara per determinar** es mostraven com "Desconegut"/en blanc al calendari general i al widget de properes partides, i s'**amagaven completament** al dashboard d'hàndicap (filtrava només `estat = 'programada'`).

Ara, igual que al [calendari d'hàndicap](src/routes/handicap/calendari/+page.svelte), mostren el nom del jugador conegut i **d'on ve l'altre contrincant** ("Guanyador W1.1", "Perdedor L2.3").

## Causa d'arrel

El calendari d'hàndicap deriva els noms del **bracket**; els altres llocs llegien directament `calendari_partides.jugador*_soci_numero`, que queda NULL mentre el slot ve d'una partida futura.

## Canvis

- **Nova utilitat** `handicap-calendar-labels.ts`: resol l'origen dels slots pendents des del bracket (`calendari_partida_id → handicap_matches → slots`), reaprofitant `buildMatchCodeMap`/`buildSlotSourceMap`.
- **`calendar.ts`**: etiqueta les partides d'hàndicap al calendari general → arregla el "Properes activitats" de la home **i** `/general/calendari`.
- **`MyUpcomingMatchesWidget`**: contrincant pendent amb l'origen en cursiva.
- **Dashboard d'hàndicap**: inclou les pre-reserves `pendent` ja programades (n'amagava 14) amb guard de data per no treure dies passats.

## Verificació

- `npm run check`: 0 errors, 0 warnings.
- Comprovat amb dades de prod: els 14 partits `pendent` ja programats resolen tots un origen vàlid (cap cau a "Per determinar").

🤖 Generated with [Claude Code](https://claude.com/claude-code)